### PR TITLE
fix: 루트 URL 리디렉션 경로 수정

### DIFF
--- a/src/main/kotlin/com/seek/thebible/presentation/RootController.kt
+++ b/src/main/kotlin/com/seek/thebible/presentation/RootController.kt
@@ -1,0 +1,13 @@
+package com.seek.thebible.presentation
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+@Controller
+class RootController {
+
+    @GetMapping("/")
+    fun redirectToWebBibles(): String {
+        return "redirect:/web/bibles/translations"
+    }
+}


### PR DESCRIPTION
- 기존 루트("/") 요청 시 `/web/bibles/translations`로 리디렉션되던 것을 `/web/bibles`로 변경
- 변경된 웹 UI 구조에 맞춰 적절한 리디렉션 경로로 수정

이번 변경으로 루트 접근 시 보다 적절한 경로로 이동하도록 개선됨.