### PR TITLE
feat: 모든 템플릿 페이지에 반응형 meta 태그 추가

### DIFF
--- a/src/main/resources/templates/books.html
+++ b/src/main/resources/templates/books.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <title>책 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="/webjars/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/common.css" rel="stylesheet">
 </head>

--- a/src/main/resources/templates/chapters.html
+++ b/src/main/resources/templates/chapters.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <title>장 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="/webjars/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/common.css" rel="stylesheet">
 </head>

--- a/src/main/resources/templates/translations.html
+++ b/src/main/resources/templates/translations.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <title>성경 번역본 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="/webjars/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/common.css" rel="stylesheet">
 </head>

--- a/src/main/resources/templates/verses.html
+++ b/src/main/resources/templates/verses.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <title>절 목록</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="/webjars/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/common.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
- `translations.html`, `books.html`, `chapters.html`, `verses.html`에 `<meta name="viewport" content="width=device-width, initial-scale=1.0">` 추가
- 모바일 환경에서도 원활한 UI 제공을 위해 반응형 디자인 지원 강화
- 모든 템플릿의 `<html>` 태그에 `lang="ko"` 속성 추가하여 접근성과 SEO 개선

이번 변경으로 성경 탐색 웹 UI가 모바일 및 다양한 화면 크기에서도 최적화된 레이아웃을 제공할 수 있도록 개선됨.