### PR TITLE
fix: FAB 메뉴가 열린 상태에서 구절 영역 클릭 시 메뉴 닫기

### DIFF
--- a/src/main/resources/static/js/bible/verse-list.js
+++ b/src/main/resources/static/js/bible/verse-list.js
@@ -420,6 +420,10 @@ const App = {
     },
 
     handleVerseClick: async event => {
+        if (App.selection.menuOpen) {
+            App.closeFabMenu();
+            return;
+        }
         if (event.target.classList.contains("memo-save-btn")) {
             const verseNum = event.target.dataset.verse;
             await App.saveMemo(verseNum);


### PR DESCRIPTION
FAB 메뉴가 펼쳐진 상태에서 성경 구절 영역을 클릭하면
구절 선택/해제 대신 메뉴를 닫도록 처리.
메뉴 내부 클릭은 기존 동작 유지.

https://claude.ai/code/session_01AwH5rjRMXfgYwH12M4o2zs