### PR TITLE
fix: 홈 최초 진입 시에만 localStorage 기반 구절 화면 리다이렉트

### DIFF
--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,5 +1,5 @@
 import {fetchWithAuthRetry} from "/js/common-util.js?v=2.1";
-import {LastReadStore, SessionStore, STORAGE_KEYS, TranslationStore} from "/js/storage-util.js?v=2.1";
+import {LastReadStore, TranslationStore} from "/js/storage-util.js?v=2.1";
 
 const updateText = (element, value) => {
     if (!element) {
@@ -9,9 +9,9 @@ const updateText = (element, value) => {
 };
 
 document.addEventListener("DOMContentLoaded", async () => {
-    const skipAutoRedirect = SessionStore.consume(STORAGE_KEYS.SKIP_HOME_REDIRECT);
+    const isInternalNavigation = document.referrer && new URL(document.referrer).origin === window.location.origin;
     const lastRead = LastReadStore.get();
-    if (lastRead && !skipAutoRedirect) {
+    if (lastRead && !isInternalNavigation) {
         const verseUrl = new URL("/web/bible/verse", window.location.origin);
         verseUrl.searchParams.set("translationId", lastRead.translationId);
         verseUrl.searchParams.set("bookOrder", lastRead.bookOrder);
@@ -117,7 +117,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         dailyVerseLink.addEventListener("click", () => {
             const targetUrl = dailyVerseLink.dataset.verseUrl;
             if (targetUrl) {
-                SessionStore.set(STORAGE_KEYS.SKIP_HOME_REDIRECT, true);
                 window.location.href = targetUrl;
             }
         });
@@ -126,7 +125,6 @@ document.addEventListener("DOMContentLoaded", async () => {
                 event.preventDefault();
                 const targetUrl = dailyVerseLink.dataset.verseUrl;
                 if (targetUrl) {
-                    SessionStore.set(STORAGE_KEYS.SKIP_HOME_REDIRECT, true);
                     window.location.href = targetUrl;
                 }
             }

--- a/src/main/resources/static/js/member/mypage.js
+++ b/src/main/resources/static/js/member/mypage.js
@@ -1,6 +1,5 @@
 import {buildLoginRedirectUrl, checkAuthStatus, showAuthError} from "/js/auth/auth-check.js";
 import {fetchWithAuthRetry} from "/js/common-util.js?v=2.1";
-import {LastReadStore} from "/js/storage-util.js?v=2.1";
 
 const roleLabels = {
     ADMIN: "관리자",
@@ -38,7 +37,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const editForm = document.getElementById("mypageEditForm");
     const nicknameInput = document.getElementById("mypageNicknameInput");
     const saveButton = document.getElementById("mypageSaveButton");
-    const homeButton = document.querySelector(".top-nav-home-button");
     const oauthActionButtons = document.querySelectorAll(".mypage-oauth-action");
     const confirmModal = document.getElementById("mypageOAuthConfirmModal");
     const confirmCancel = document.getElementById("mypageOAuthConfirmCancel");
@@ -332,11 +330,6 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     setFormEnabled(false);
-    if (homeButton) {
-        homeButton.addEventListener("click", () => {
-            LastReadStore.clear();
-        });
-    }
     if (oauthActionButtons && oauthActionButtons.length > 0) {
         oauthActionButtons.forEach((button) => {
             button.addEventListener("click", handleOAuthAction);


### PR DESCRIPTION
document.referrer를 활용하여 같은 사이트 내부에서 홈으로 이동한 경우는
리다이렉트하지 않고, 최초 진입(직접 URL 입력, 북마크, 새 탭 등)인 경우에만
localStorage의 lastReadLocation 기반으로 구절 화면으로 이동하도록 변경.

기존 SessionStore SKIP_HOME_REDIRECT 플래그 및 LastReadStore.clear() 로직 제거.

https://claude.ai/code/session_01JzVpfJ8EMdEH29GL8YZiML