### PR TITLE
refactor: 커뮤니티 페이지에서 이용가이드 영역 제거

### DIFF
--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -47,40 +47,18 @@
             <h3 class="h5 fw-bold text-dark mb-0">공지사항</h3>
             <a href="#" class="text-decoration-none small text-muted">더보기</a>
         </div>
-        <div class="row g-4">
-            <div class="col-12 col-lg-7">
-                <div class="card border-0 shadow-sm community-animate" style="--delay: 0.08s;" id="communityNotices">
-                    <div class="card-body">
-                        <ul class="list-group list-group-flush community-notice-list small">
-                            <li class="list-group-item px-0 py-2 d-flex justify-content-between align-items-center border-bottom">
-                                <span class="text-truncate">커뮤니티 오픈 준비 중</span>
-                                <span class="badge bg-light text-muted">공지</span>
-                            </li>
-                            <li class="list-group-item px-0 py-2 d-flex justify-content-between align-items-center border-bottom">
-                                <span class="text-truncate">이용 가이드 안내</span>
-                                <span class="badge bg-light text-muted">필독</span>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="col-12 col-lg-5">
-                <div class="card border-0 shadow-sm community-animate" style="--delay: 0.12s;" id="communityGuide">
-                    <div class="card-body">
-                        <h3 class="h6 fw-bold text-secondary mb-3">📖 이용 가이드</h3>
-                        <ul class="list-unstyled mb-0 community-guide text-muted small px-2">
-                            <li class="mb-2">
-                                <span class="me-1">✔</span> 서로 존중하는 대화
-                            </li>
-                            <li class="mb-2">
-                                <span class="me-1">✔</span> 이단/사이비 논쟁 금지
-                            </li>
-                            <li>
-                                <span class="me-1">✔</span> 개인정보 공유 주의
-                            </li>
-                        </ul>
-                    </div>
-                </div>
+        <div class="card border-0 shadow-sm community-animate" style="--delay: 0.08s;" id="communityNotices">
+            <div class="card-body">
+                <ul class="list-group list-group-flush community-notice-list small">
+                    <li class="list-group-item px-0 py-2 d-flex justify-content-between align-items-center border-bottom">
+                        <span class="text-truncate">커뮤니티 오픈 준비 중</span>
+                        <span class="badge bg-light text-muted">공지</span>
+                    </li>
+                    <li class="list-group-item px-0 py-2 d-flex justify-content-between align-items-center border-bottom">
+                        <span class="text-truncate">이용 가이드 안내</span>
+                        <span class="badge bg-light text-muted">필독</span>
+                    </li>
+                </ul>
             </div>
         </div>
     </section>


### PR DESCRIPTION
공지사항 옆 이용 가이드 카드(communityGuide)를 제거하고,
공지사항 카드가 전체 너비를 사용하도록 레이아웃 변경

https://claude.ai/code/session_018LVESPEqLrGL6Frbq9FLDY