### PR TITLE
refactor: 알림 버튼을 커뮤니티 페이지에서 네비게이션 바로 이동

### DIFF
--- a/src/main/resources/static/css/top-nav.css
+++ b/src/main/resources/static/css/top-nav.css
@@ -96,6 +96,39 @@
     transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
 }
 
+.top-nav-notification-button {
+    position: relative;
+    min-width: 44px;
+    max-width: 44px;
+    flex: 0 0 44px;
+    padding: 0.375rem 0.5rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border-radius: 0.375rem;
+}
+
+.top-nav-notification-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+    pointer-events: none;
+}
+
+.top-nav-notification-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+    color: #fff;
+    background: #dc3545;
+    border-radius: 10px;
+}
+
 .top-nav-account {
     position: relative;
     display: flex;

--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -28,13 +28,6 @@
                                 <div class="community-action-desc">인기글 모음</div>
                             </div>
                         </div>
-                        <div class="community-action coming-soon">
-                            <div class="card-body">
-                                <div class="community-action-icon">🔔</div>
-                                <div class="community-action-title">알림</div>
-                                <div class="community-action-desc">나의 소식</div>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -37,6 +37,15 @@
                        title="본문 검색">
                         🔍
                     </a>
+                    <button id="topNavNotificationButton"
+                            type="button"
+                            class="top-nav-notification-button top-nav-btn btn btn-outline-secondary d-none"
+                            aria-label="알림"
+                            title="알림"
+                            disabled>
+                        🔔
+                        <span id="topNavNotificationBadge" class="top-nav-notification-badge d-none"></span>
+                    </button>
                     <div class="top-nav-account">
                         <button id="topNavAccountButton"
                                 type="button"
@@ -101,11 +110,16 @@
             loginLink.href = buildLoginRedirectUrl(returnUrl);
             logoutLink.href = `/web/auth/logout?returnUrl=${encodeURIComponent(returnUrl)}`;
 
+            const notificationButton = document.getElementById("topNavNotificationButton");
+
             checkAuthStatus({
                 onAuthenticated: () => {
                     logoutLink.classList.remove("d-none");
                     myPageLink.classList.remove("d-none");
                     accountDivider.classList.remove("d-none");
+                    if (notificationButton) {
+                        notificationButton.classList.remove("d-none");
+                    }
                 },
                 onUnauthenticated: () => {
                     loginLink.classList.remove("d-none");


### PR DESCRIPTION
알림은 커뮤니티 전용 기능이 아니라 서비스 전체에 걸친 글로벌 기능이므로
상단 네비게이션 바에 배치하는 것이 UX 컨벤션에 적합함.

- 커뮤니티 인트로 섹션에서 알림 카드 제거
- header fragment의 top-nav-right에 알림 벨 버튼 추가
- 로그인 사용자에게만 알림 버튼 표시 (disabled 상태 유지)
- 알림 배지 UI 준비 (향후 알림 카운트 표시용)

https://claude.ai/code/session_016nz2Uf45GH4G24kKnJ6HK3