### PR TITLE
Remove ranking badges (1위, 2위, 3위) from weekly popular posts section

### DIFF
--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -63,7 +63,6 @@
                                     <a href="#" class="feed-card top3-card-mobile coming-soon" data-rank="1">
                                         <div class="feed-top-row">
                                             <div class="feed-badges">
-                                                <span class="rank-badge rank-1">1위</span>
                                                 <span class="feed-category-badge">자유</span>
                                             </div>
                                         </div>
@@ -81,7 +80,6 @@
                                     <a href="#" class="feed-card top3-card-mobile coming-soon" data-rank="2">
                                         <div class="feed-top-row">
                                             <div class="feed-badges">
-                                                <span class="rank-badge rank-2">2위</span>
                                                 <span class="feed-category-badge">기도</span>
                                             </div>
                                         </div>
@@ -99,7 +97,6 @@
                                     <a href="#" class="feed-card top3-card-mobile coming-soon" data-rank="3">
                                         <div class="feed-top-row">
                                             <div class="feed-badges">
-                                                <span class="rank-badge rank-3">3위</span>
                                                 <span class="feed-category-badge">Q&A</span>
                                             </div>
                                         </div>
@@ -240,7 +237,6 @@
                         <a href="#" class="feed-card top3-card-desktop coming-soon" data-rank="1">
                             <div class="feed-top-row">
                                 <div class="feed-badges">
-                                    <span class="rank-badge rank-1">1위</span>
                                     <span class="feed-category-badge">자유</span>
                                 </div>
                             </div>
@@ -258,7 +254,6 @@
                         <a href="#" class="feed-card top3-card-desktop coming-soon" data-rank="2">
                             <div class="feed-top-row">
                                 <div class="feed-badges">
-                                    <span class="rank-badge rank-2">2위</span>
                                     <span class="feed-category-badge">기도</span>
                                 </div>
                             </div>
@@ -276,7 +271,6 @@
                         <a href="#" class="feed-card top3-card-desktop coming-soon" data-rank="3">
                             <div class="feed-top-row">
                                 <div class="feed-badges">
-                                    <span class="rank-badge rank-3">3위</span>
                                     <span class="feed-category-badge">Q&A</span>
                                 </div>
                             </div>


### PR DESCRIPTION
Remove rank-badge spans from both mobile and desktop top3 widgets
in community.html, keeping only the category badges.

https://claude.ai/code/session_016ZDdGoMzfQxfrh9HxsVxGq