### PR TITLE
커뮤니티 카테고리 탭과 공지사항 영역 간격 증가

### DIFF
--- a/src/main/resources/static/css/community/community.css
+++ b/src/main/resources/static/css/community/community.css
@@ -54,7 +54,7 @@ body {
     margin: 0 -0.75rem 1rem -0.75rem;
     /* Negative margin to pull it to edges of grid column if needed, or just stay within */
     /* Actually, better to just keep it simple first */
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
     border-bottom: 1px solid var(--comm-border);
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
     /* Subtle shadow for depth */


### PR DESCRIPTION
.community-tabs-wrapper의 margin-bottom을 1rem에서 2rem으로 늘려
카테고리 메뉴와 하단 콘텐츠(공지사항) 간 여백을 확보

https://claude.ai/code/session_01REybLVW9SdFaUhiiUpXxN5