### PR TITLE
주간 인기글 카드 내 조회수/좋아요/댓글 통계를 오른쪽 정렬

### DIFF
--- a/src/main/resources/static/css/community/community.css
+++ b/src/main/resources/static/css/community/community.css
@@ -495,6 +495,11 @@ body {
     border: 1px solid var(--comm-border);
 }
 
+.top3-card-mobile .feed-footer,
+.top3-card-desktop .feed-footer {
+    justify-content: flex-end;
+}
+
 .rank-badge {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
피드 리스트 카드와 동일하게 주간 인기글 카드의 feed-actions를
오른쪽으로 정렬. top3 카드에는 feed-user-info가 없어
space-between이 의미 없었으므로 flex-end로 변경.

https://claude.ai/code/session_01D2vBVM8ZfrnGGKYptKuowN