### PR TITLE
feat: 커뮤니티 백엔드 REST API 구현 (Post, Reaction, Comment)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 val springDocVersion = "2.8.14"
 val kotlinLogging = "3.0.5"
 val kotestVersion = "5.9.1"
+val kotlinJdslVersion = "3.5.5"
 
 dependencies {
     // kotlin-logging
@@ -47,6 +48,11 @@ dependencies {
 
     // SpringDoc
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}")
+
+    // Kotlin JDSL
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:${kotlinJdslVersion}")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:${kotlinJdslVersion}")
+    implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:${kotlinJdslVersion}")
 
     // DB
     implementation("org.postgresql:postgresql")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "el_seeker"

--- a/src/main/kotlin/com/elseeker/common/domain/ErrorType.kt
+++ b/src/main/kotlin/com/elseeker/common/domain/ErrorType.kt
@@ -38,6 +38,12 @@ enum class ErrorType(
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다.", LogLevel.WARN),
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다.", LogLevel.WARN),
     VERSE_NOT_FOUND(HttpStatus.NOT_FOUND, "구절을 찾을 수 없습니다.", LogLevel.WARN),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다.", LogLevel.WARN),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.", LogLevel.WARN),
+    REACTION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 반응한 게시글입니다.", LogLevel.WARN),
+    REACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "반응을 찾을 수 없습니다.", LogLevel.WARN),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글에 대한 접근 권한이 없습니다.", LogLevel.WARN),
+    COMMENT_DISABLED(HttpStatus.BAD_REQUEST, "댓글이 비활성화된 게시글입니다.", LogLevel.WARN),
 
     // 403
     MEMBER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "요청한 회원 정보에 접근할 수 없습니다.", LogLevel.WARN),

--- a/src/main/kotlin/com/elseeker/common/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/elseeker/common/security/SecurityConfig.kt
@@ -76,6 +76,7 @@ class SecurityConfig(
                 auth
                     // 관리자 전용 페이지 및 API
                     .requestMatchers("/web/admin/**", "/api/v1/admin/**").hasRole("ADMIN")
+                    .requestMatchers("/api/v1/community/admin/**").hasRole("ADMIN")
                     .requestMatchers(
                     "/api/v1/bibles/translations/{translationId}/books/{bookOrder}/chapters/{chapterNumber}/memos",
                     "/api/v1/bibles/translations/{translationId}/books/{bookOrder}/chapters/{chapterNumber}/verses/{verseNumber}/memo",
@@ -94,6 +95,13 @@ class SecurityConfig(
                         "/api/v1/bibles/**",
                         "/api/v1/study/dictionaries/**",
                         "/api/v1/auth/refresh"
+                    ).permitAll()
+                    .requestMatchers(
+                        org.springframework.http.HttpMethod.GET,
+                        "/api/v1/community/posts",
+                        "/api/v1/community/posts/top",
+                        "/api/v1/community/posts/{postId}",
+                        "/api/v1/community/posts/{postId}/comments"
                     ).permitAll()
                     .requestMatchers(
                         "/api/v1/auth/me",

--- a/src/main/kotlin/com/elseeker/community/adapter/input/api/CommunityApi.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/input/api/CommunityApi.kt
@@ -1,0 +1,134 @@
+package com.elseeker.community.adapter.input.api
+
+import com.elseeker.common.security.jwt.JwtPrincipal
+import com.elseeker.community.adapter.input.api.request.CreateCommentRequest
+import com.elseeker.community.adapter.input.api.request.CreatePostRequest
+import com.elseeker.community.adapter.input.api.request.CreateReactionRequest
+import com.elseeker.community.adapter.input.api.request.UpdatePostRequest
+import com.elseeker.community.adapter.input.api.response.*
+import com.elseeker.community.application.service.CommentService
+import com.elseeker.community.application.service.PostService
+import com.elseeker.community.application.service.ReactionService
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.community.domain.vo.PostType
+import com.elseeker.community.domain.vo.ReactionType
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/community")
+class CommunityApi(
+    private val postService: PostService,
+    private val reactionService: ReactionService,
+    private val commentService: CommentService,
+) : CommunityApiDocument {
+
+    @GetMapping("/posts")
+    override fun getClientPosts(
+        @RequestParam(required = false) type: PostType?,
+        @RequestParam(defaultValue = "latest") sort: String,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): ResponseEntity<PostSliceResponse> {
+        val response = postService.getClientPosts(type, sort, pageable)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/admin/posts")
+    override fun getAdminPosts(
+        @RequestParam(required = false) type: PostType?,
+        @RequestParam(required = false) status: PostStatus?,
+        @PageableDefault(size = 20) pageable: Pageable,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<PostPageResponse> {
+        val response = postService.getAdminPosts(type, status, pageable)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/posts/{postId}")
+    override fun getPostDetail(
+        @PathVariable postId: Long,
+    ): ResponseEntity<PostDetailResponse> {
+        val response = postService.getPostDetail(postId)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/posts")
+    override fun createPost(
+        @Valid @RequestBody request: CreatePostRequest,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<PostDetailResponse> {
+        val response = postService.createPost(principal.memberUid, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @PutMapping("/posts/{postId}")
+    override fun updatePost(
+        @PathVariable postId: Long,
+        @Valid @RequestBody request: UpdatePostRequest,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<PostDetailResponse> {
+        val response = postService.updatePost(postId, principal.memberUid, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    override fun deletePost(
+        @PathVariable postId: Long,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<Void> {
+        postService.deletePost(postId, principal.memberUid)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/posts/{postId}/reactions")
+    override fun addReaction(
+        @PathVariable postId: Long,
+        @Valid @RequestBody request: CreateReactionRequest,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<Void> {
+        reactionService.addReaction(postId, principal.memberUid, request.type)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/posts/{postId}/reactions/{type}")
+    override fun removeReaction(
+        @PathVariable postId: Long,
+        @PathVariable type: ReactionType,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<Void> {
+        reactionService.removeReaction(postId, principal.memberUid, type)
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    override fun getComments(
+        @PathVariable postId: Long,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): ResponseEntity<CommentSliceResponse> {
+        val response = commentService.getComments(postId, pageable)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/posts/{postId}/comments")
+    override fun createComment(
+        @PathVariable postId: Long,
+        @Valid @RequestBody request: CreateCommentRequest,
+        @AuthenticationPrincipal principal: JwtPrincipal,
+    ): ResponseEntity<CommentResponse> {
+        val response = commentService.createComment(postId, principal.memberUid, request.content)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/posts/top")
+    override fun getTopPosts(): ResponseEntity<List<PostSummaryResponse>> {
+        val response = postService.getTopPosts()
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/elseeker/community/adapter/input/api/CommunityApiDocument.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/input/api/CommunityApiDocument.kt
@@ -1,0 +1,136 @@
+package com.elseeker.community.adapter.input.api
+
+import com.elseeker.community.adapter.input.api.request.CreateCommentRequest
+import com.elseeker.community.adapter.input.api.request.CreatePostRequest
+import com.elseeker.community.adapter.input.api.request.CreateReactionRequest
+import com.elseeker.community.adapter.input.api.request.UpdatePostRequest
+import com.elseeker.community.adapter.input.api.response.*
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.community.domain.vo.PostType
+import com.elseeker.community.domain.vo.ReactionType
+import com.elseeker.common.security.jwt.JwtPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+
+@Tag(name = "Community", description = "커뮤니티 API")
+interface CommunityApiDocument {
+
+    @Operation(summary = "게시글 목록 조회 (클라이언트)", description = "Slice 기반 게시글 목록을 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    fun getClientPosts(
+        @Parameter(description = "게시글 유형 필터") type: PostType?,
+        @Parameter(description = "정렬 기준 (latest / popular)") sort: String,
+        pageable: Pageable,
+    ): ResponseEntity<PostSliceResponse>
+
+    @Operation(summary = "게시글 목록 조회 (관리자)", description = "Page 기반 게시글 목록을 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "관리자 권한 필요"),
+    )
+    fun getAdminPosts(
+        @Parameter(description = "게시글 유형 필터") type: PostType?,
+        @Parameter(description = "게시글 상태 필터") status: PostStatus?,
+        pageable: Pageable,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<PostPageResponse>
+
+    @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보를 조회하고 조회수를 증가시킵니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "404", description = "게시글 없음"),
+    )
+    fun getPostDetail(
+        @Parameter(description = "게시글 ID") postId: Long,
+    ): ResponseEntity<PostDetailResponse>
+
+    @Operation(summary = "게시글 작성", description = "새 게시글을 작성합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "작성 성공"),
+        ApiResponse(responseCode = "401", description = "인증 필요"),
+    )
+    fun createPost(
+        @Valid request: CreatePostRequest,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<PostDetailResponse>
+
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "수정 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "게시글 없음"),
+    )
+    fun updatePost(
+        @Parameter(description = "게시글 ID") postId: Long,
+        @Valid request: UpdatePostRequest,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<PostDetailResponse>
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다 (soft delete).")
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "게시글 없음"),
+    )
+    fun deletePost(
+        @Parameter(description = "게시글 ID") postId: Long,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<Void>
+
+    @Operation(summary = "반응 추가", description = "게시글에 반응(LIKE, PRAY)을 추가합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "반응 추가 성공"),
+        ApiResponse(responseCode = "400", description = "이미 반응한 게시글"),
+        ApiResponse(responseCode = "401", description = "인증 필요"),
+    )
+    fun addReaction(
+        @Parameter(description = "게시글 ID") postId: Long,
+        @Valid request: CreateReactionRequest,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<Void>
+
+    @Operation(summary = "반응 취소", description = "게시글 반응을 취소합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "반응 취소 성공"),
+        ApiResponse(responseCode = "404", description = "반응 없음"),
+    )
+    fun removeReaction(
+        @Parameter(description = "게시글 ID") postId: Long,
+        @Parameter(description = "반응 유형") type: ReactionType,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<Void>
+
+    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    fun getComments(
+        @Parameter(description = "게시글 ID") postId: Long,
+        pageable: Pageable,
+    ): ResponseEntity<CommentSliceResponse>
+
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "작성 성공"),
+        ApiResponse(responseCode = "401", description = "인증 필요"),
+    )
+    fun createComment(
+        @Parameter(description = "게시글 ID") postId: Long,
+        @Valid request: CreateCommentRequest,
+        @Parameter(hidden = true) principal: JwtPrincipal,
+    ): ResponseEntity<CommentResponse>
+
+    @Operation(summary = "주간 인기글 Top 3", description = "최근 7일간 인기글 상위 3개를 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+    )
+    fun getTopPosts(): ResponseEntity<List<PostSummaryResponse>>
+}

--- a/src/main/kotlin/com/elseeker/community/adapter/input/api/request/CommunityRequests.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/input/api/request/CommunityRequests.kt
@@ -1,0 +1,67 @@
+package com.elseeker.community.adapter.input.api.request
+
+import com.elseeker.community.domain.vo.PostType
+import com.elseeker.community.domain.vo.ReactionType
+import com.neovisionaries.i18n.CountryCode
+import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+@Schema(description = "게시글 작성 요청")
+data class CreatePostRequest(
+    @field:NotNull(message = "게시글 유형은 필수입니다")
+    @field:Schema(description = "게시글 유형", example = "FREE")
+    val type: PostType,
+
+    @field:NotNull(message = "언어 코드는 필수입니다")
+    @field:Schema(description = "언어 코드", example = "ko")
+    val language: LanguageCode,
+
+    @field:NotNull(message = "국가 코드는 필수입니다")
+    @field:Schema(description = "국가 코드", example = "KR")
+    val country: CountryCode,
+
+    @field:NotBlank(message = "제목은 필수입니다")
+    @field:Size(max = 200, message = "제목은 200자 이내여야 합니다")
+    @field:Schema(description = "제목", example = "오늘의 묵상")
+    val title: String,
+
+    @field:NotBlank(message = "본문은 필수입니다")
+    @field:Schema(description = "본문 내용")
+    val content: String,
+
+    @field:Schema(description = "댓글 사용 여부", example = "true")
+    val useReply: Boolean = true,
+
+    @field:Schema(description = "HTML 본문 여부", example = "false")
+    val isHtml: Boolean = false,
+)
+
+@Schema(description = "게시글 수정 요청")
+data class UpdatePostRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    @field:Size(max = 200, message = "제목은 200자 이내여야 합니다")
+    @field:Schema(description = "제목", example = "수정된 제목")
+    val title: String,
+
+    @field:NotBlank(message = "본문은 필수입니다")
+    @field:Schema(description = "본문 내용")
+    val content: String,
+)
+
+@Schema(description = "반응 추가 요청")
+data class CreateReactionRequest(
+    @field:NotNull(message = "반응 유형은 필수입니다")
+    @field:Schema(description = "반응 유형", example = "LIKE")
+    val type: ReactionType,
+)
+
+@Schema(description = "댓글 작성 요청")
+data class CreateCommentRequest(
+    @field:NotBlank(message = "댓글 내용은 필수입니다")
+    @field:Size(max = 1000, message = "댓글은 1000자 이내여야 합니다")
+    @field:Schema(description = "댓글 내용", example = "아멘!")
+    val content: String,
+)

--- a/src/main/kotlin/com/elseeker/community/adapter/input/api/response/CommunityResponses.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/input/api/response/CommunityResponses.kt
@@ -1,0 +1,122 @@
+package com.elseeker.community.adapter.input.api.response
+
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.community.domain.vo.PostType
+import com.neovisionaries.i18n.CountryCode
+import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "게시글 요약 응답")
+data class PostSummaryResponse(
+    @field:Schema(description = "게시글 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "게시글 유형", example = "FREE")
+    val type: PostType,
+    @field:Schema(description = "제목", example = "오늘의 묵상")
+    val title: String,
+    @field:Schema(description = "작성자 닉네임", example = "은혜")
+    val authorNickname: String,
+    @field:Schema(description = "게시글 상태", example = "PUBLISHED")
+    val status: PostStatus,
+    @field:Schema(description = "조회수", example = "42")
+    val viewCount: Long,
+    @field:Schema(description = "반응 수", example = "5")
+    val reactionCount: Long,
+    @field:Schema(description = "댓글 수", example = "3")
+    val commentCount: Long,
+    @field:Schema(description = "인기글 여부", example = "false")
+    val isPopular: Boolean,
+    @field:Schema(description = "작성일시 (UTC)", example = "2025-01-15T10:30:00Z")
+    val createdAt: Instant,
+)
+
+@Schema(description = "게시글 상세 응답")
+data class PostDetailResponse(
+    @field:Schema(description = "게시글 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "게시글 유형", example = "FREE")
+    val type: PostType,
+    @field:Schema(description = "언어 코드", example = "ko")
+    val language: LanguageCode,
+    @field:Schema(description = "국가 코드", example = "KR")
+    val country: CountryCode,
+    @field:Schema(description = "제목")
+    val title: String,
+    @field:Schema(description = "본문 내용")
+    val content: String,
+    @field:Schema(description = "작성자 닉네임")
+    val authorNickname: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL")
+    val authorProfileImageUrl: String?,
+    @field:Schema(description = "게시글 상태")
+    val status: PostStatus,
+    @field:Schema(description = "조회수")
+    val viewCount: Long,
+    @field:Schema(description = "반응 수")
+    val reactionCount: Long,
+    @field:Schema(description = "댓글 수")
+    val commentCount: Long,
+    @field:Schema(description = "인기 점수")
+    val score: Long,
+    @field:Schema(description = "인기글 여부")
+    val isPopular: Boolean,
+    @field:Schema(description = "댓글 사용 여부")
+    val useReply: Boolean,
+    @field:Schema(description = "HTML 본문 여부")
+    val isHtml: Boolean,
+    @field:Schema(description = "작성일시 (UTC)")
+    val createdAt: Instant,
+    @field:Schema(description = "수정일시 (UTC)")
+    val updatedAt: Instant,
+)
+
+@Schema(description = "게시글 Slice 응답 (클라이언트)")
+data class PostSliceResponse(
+    @field:Schema(description = "게시글 목록")
+    val content: List<PostSummaryResponse>,
+    @field:Schema(description = "다음 페이지 존재 여부")
+    val hasNext: Boolean,
+    @field:Schema(description = "페이지 크기")
+    val size: Int,
+    @field:Schema(description = "현재 페이지 번호")
+    val number: Int,
+)
+
+@Schema(description = "게시글 Page 응답 (관리자)")
+data class PostPageResponse(
+    @field:Schema(description = "게시글 목록")
+    val content: List<PostSummaryResponse>,
+    @field:Schema(description = "전체 게시글 수")
+    val totalElements: Long,
+    @field:Schema(description = "전체 페이지 수")
+    val totalPages: Int,
+    @field:Schema(description = "페이지 크기")
+    val size: Int,
+    @field:Schema(description = "현재 페이지 번호")
+    val number: Int,
+)
+
+@Schema(description = "댓글 응답")
+data class CommentResponse(
+    @field:Schema(description = "댓글 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "댓글 내용")
+    val content: String,
+    @field:Schema(description = "작성자 닉네임")
+    val authorNickname: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL")
+    val authorProfileImageUrl: String?,
+    @field:Schema(description = "삭제 여부")
+    val deleted: Boolean,
+    @field:Schema(description = "작성일시 (UTC)")
+    val createdAt: Instant,
+)
+
+@Schema(description = "댓글 Slice 응답")
+data class CommentSliceResponse(
+    @field:Schema(description = "댓글 목록")
+    val content: List<CommentResponse>,
+    @field:Schema(description = "다음 페이지 존재 여부")
+    val hasNext: Boolean,
+)

--- a/src/main/kotlin/com/elseeker/community/adapter/output/jpa/CommentRepository.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/output/jpa/CommentRepository.kt
@@ -1,0 +1,21 @@
+package com.elseeker.community.adapter.output.jpa
+
+import com.elseeker.community.domain.model.Comment
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+
+    @Query(
+        """
+        SELECT c FROM Comment c
+        JOIN FETCH c.author
+        WHERE c.post.id = :postId
+        ORDER BY c.createdAt ASC
+        """
+    )
+    fun findByPostIdWithAuthor(@Param("postId") postId: Long, pageable: Pageable): Slice<Comment>
+}

--- a/src/main/kotlin/com/elseeker/community/adapter/output/jpa/PostReactionRepository.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/output/jpa/PostReactionRepository.kt
@@ -1,0 +1,12 @@
+package com.elseeker.community.adapter.output.jpa
+
+import com.elseeker.community.domain.model.PostReaction
+import com.elseeker.community.domain.vo.ReactionType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostReactionRepository : JpaRepository<PostReaction, Long> {
+
+    fun findByPostIdAndMemberIdAndType(postId: Long, memberId: Long, type: ReactionType): PostReaction?
+
+    fun existsByPostIdAndMemberIdAndType(postId: Long, memberId: Long, type: ReactionType): Boolean
+}

--- a/src/main/kotlin/com/elseeker/community/adapter/output/jpa/PostRepository.kt
+++ b/src/main/kotlin/com/elseeker/community/adapter/output/jpa/PostRepository.kt
@@ -1,0 +1,59 @@
+package com.elseeker.community.adapter.output.jpa
+
+import com.elseeker.community.domain.model.Post
+import com.elseeker.community.domain.vo.PostStatus
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface PostRepository : JpaRepository<Post, Long>, KotlinJdslJpqlExecutor {
+
+    @Query(
+        """
+        SELECT p FROM Post p
+        JOIN FETCH p.author
+        WHERE p.id = :id AND p.status <> :excludedStatus
+        """
+    )
+    fun findByIdAndStatusNot(
+        @Param("id") id: Long,
+        @Param("excludedStatus") excludedStatus: PostStatus,
+    ): Post?
+
+    @Query(
+        """
+        SELECT p FROM Post p
+        JOIN FETCH p.author
+        WHERE p.id = :id
+        """
+    )
+    fun findByIdWithAuthor(@Param("id") id: Long): Post?
+
+    @Modifying
+    @Query("UPDATE Post p SET p.statistics.viewCount = p.statistics.viewCount + 1 WHERE p.id = :postId")
+    fun incrementViewCount(@Param("postId") postId: Long): Int
+
+    @Modifying
+    @Query("UPDATE Post p SET p.statistics.reactionCount = p.statistics.reactionCount + 1 WHERE p.id = :postId")
+    fun incrementReactionCount(@Param("postId") postId: Long): Int
+
+    @Modifying
+    @Query("UPDATE Post p SET p.statistics.reactionCount = p.statistics.reactionCount - 1 WHERE p.id = :postId AND p.statistics.reactionCount > 0")
+    fun decrementReactionCount(@Param("postId") postId: Long): Int
+
+    @Modifying
+    @Query("UPDATE Post p SET p.statistics.commentCount = p.statistics.commentCount + 1 WHERE p.id = :postId")
+    fun incrementCommentCount(@Param("postId") postId: Long): Int
+
+    @Modifying
+    @Query(
+        """
+        UPDATE Post p
+        SET p.statistics.score = p.statistics.viewCount + (p.statistics.reactionCount * 5) + (p.statistics.commentCount * 3)
+        WHERE p.id = :postId
+        """
+    )
+    fun updateScore(@Param("postId") postId: Long): Int
+}

--- a/src/main/kotlin/com/elseeker/community/application/service/CommentService.kt
+++ b/src/main/kotlin/com/elseeker/community/application/service/CommentService.kt
@@ -1,0 +1,78 @@
+package com.elseeker.community.application.service
+
+import com.elseeker.common.domain.ErrorType
+import com.elseeker.common.domain.throwError
+import com.elseeker.community.adapter.input.api.response.CommentResponse
+import com.elseeker.community.adapter.input.api.response.CommentSliceResponse
+import com.elseeker.community.adapter.output.jpa.CommentRepository
+import com.elseeker.community.adapter.output.jpa.PostRepository
+import com.elseeker.community.domain.model.Comment
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.member.adapter.output.jpa.MemberRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class CommentService(
+    private val commentRepository: CommentRepository,
+    private val postRepository: PostRepository,
+    private val memberRepository: MemberRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getComments(postId: Long, pageable: Pageable): CommentSliceResponse {
+        val post = postRepository.findByIdAndStatusNot(postId, PostStatus.DELETED)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        if (post.status == PostStatus.HIDDEN) {
+            throwError(ErrorType.POST_ACCESS_DENIED, "postId=$postId")
+        }
+
+        val slice = commentRepository.findByPostIdWithAuthor(postId, pageable)
+
+        return CommentSliceResponse(
+            content = slice.content.map { it.toResponse() },
+            hasNext = slice.hasNext(),
+        )
+    }
+
+    @Transactional
+    fun createComment(postId: Long, memberUid: UUID, content: String): CommentResponse {
+        val post = postRepository.findByIdAndStatusNot(postId, PostStatus.DELETED)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        if (post.status == PostStatus.HIDDEN) {
+            throwError(ErrorType.POST_ACCESS_DENIED, "postId=$postId")
+        }
+
+        if (!post.useReply) {
+            throwError(ErrorType.COMMENT_DISABLED, "postId=$postId")
+        }
+
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        val comment = Comment.create(
+            post = post,
+            author = member,
+            content = content,
+        )
+        val saved = commentRepository.save(comment)
+
+        postRepository.incrementCommentCount(postId)
+        postRepository.updateScore(postId)
+
+        return saved.toResponse()
+    }
+
+    private fun Comment.toResponse() = CommentResponse(
+        id = requireNotNull(this.id),
+        content = if (this.deleted) "" else this.content,
+        authorNickname = this.author.nickname,
+        authorProfileImageUrl = this.author.profileImageUrl,
+        deleted = this.deleted,
+        createdAt = this.createdAt,
+    )
+}

--- a/src/main/kotlin/com/elseeker/community/application/service/PostService.kt
+++ b/src/main/kotlin/com/elseeker/community/application/service/PostService.kt
@@ -1,0 +1,233 @@
+package com.elseeker.community.application.service
+
+import com.elseeker.common.domain.ErrorType
+import com.elseeker.common.domain.throwError
+import com.elseeker.community.adapter.input.api.request.CreatePostRequest
+import com.elseeker.community.adapter.input.api.request.UpdatePostRequest
+import com.elseeker.community.adapter.input.api.response.*
+import com.elseeker.community.adapter.output.jpa.PostRepository
+import com.elseeker.community.domain.model.Post
+import com.elseeker.community.domain.vo.PostStatistics
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.community.domain.vo.PostType
+import com.elseeker.member.adapter.output.jpa.MemberRepository
+import com.elseeker.member.domain.vo.MemberRole
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+@Service
+class PostService(
+    private val postRepository: PostRepository,
+    private val memberRepository: MemberRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getClientPosts(
+        type: PostType?,
+        sort: String,
+        pageable: Pageable,
+    ): PostSliceResponse {
+        val slice = postRepository.findSlice(pageable) {
+            select(
+                entity(Post::class)
+            ).from(
+                entity(Post::class),
+                fetchJoin(Post::author),
+            ).whereAnd(
+                path(Post::status).eq(PostStatus.PUBLISHED),
+                type?.let { path(Post::type).eq(it) },
+            ).orderBy(
+                when (sort) {
+                    "popular" -> path(Post::statistics).path(PostStatistics::score).desc()
+                    else -> path(Post::createdAt).desc()
+                }
+            )
+        }
+
+        return PostSliceResponse(
+            content = slice.content.map { it.toSummaryResponse() },
+            hasNext = slice.hasNext(),
+            size = slice.size,
+            number = slice.number,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getAdminPosts(
+        type: PostType?,
+        status: PostStatus?,
+        pageable: Pageable,
+    ): PostPageResponse {
+        val page = postRepository.findPage(pageable) {
+            select(
+                entity(Post::class)
+            ).from(
+                entity(Post::class),
+                fetchJoin(Post::author),
+            ).whereAnd(
+                type?.let { path(Post::type).eq(it) },
+                status?.let { path(Post::status).eq(it) },
+            ).orderBy(
+                path(Post::createdAt).desc()
+            )
+        }
+
+        return PostPageResponse(
+            content = page.content.map { it.toSummaryResponse() },
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            size = page.size,
+            number = page.number,
+        )
+    }
+
+    @Transactional
+    fun getPostDetail(postId: Long): PostDetailResponse {
+        postRepository.incrementViewCount(postId)
+        postRepository.updateScore(postId)
+
+        val post = postRepository.findByIdAndStatusNot(postId, PostStatus.DELETED)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        if (post.status == PostStatus.HIDDEN) {
+            throwError(ErrorType.POST_ACCESS_DENIED, "postId=$postId")
+        }
+
+        return post.toDetailResponse()
+    }
+
+    @Transactional(readOnly = true)
+    fun getAdminPostDetail(postId: Long): PostDetailResponse {
+        val post = postRepository.findByIdWithAuthor(postId)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        return post.toDetailResponse()
+    }
+
+    @Transactional
+    fun createPost(memberUid: UUID, request: CreatePostRequest): PostDetailResponse {
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        val post = Post.create(
+            author = member,
+            postType = request.type,
+            language = request.language,
+            country = request.country,
+            title = request.title,
+            content = request.content,
+            useReply = request.useReply,
+            isHtml = request.isHtml,
+            isWrittenByAdmin = member.memberRole == MemberRole.ADMIN,
+        )
+
+        val saved = postRepository.save(post)
+        return saved.toDetailResponse()
+    }
+
+    @Transactional
+    fun updatePost(postId: Long, memberUid: UUID, request: UpdatePostRequest): PostDetailResponse {
+        val post = postRepository.findByIdWithAuthor(postId)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        if (post.author.id != member.id && member.memberRole != MemberRole.ADMIN) {
+            throwError(ErrorType.POST_ACCESS_DENIED, "postId=$postId")
+        }
+
+        post.update(title = request.title, content = request.content)
+        return post.toDetailResponse()
+    }
+
+    @Transactional
+    fun deletePost(postId: Long, memberUid: UUID) {
+        val post = postRepository.findByIdWithAuthor(postId)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        if (post.author.id != member.id && member.memberRole != MemberRole.ADMIN) {
+            throwError(ErrorType.POST_ACCESS_DENIED, "postId=$postId")
+        }
+
+        post.delete()
+    }
+
+    @Transactional
+    fun hidePost(postId: Long, memberUid: UUID) {
+        val post = postRepository.findByIdWithAuthor(postId)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        if (member.memberRole != MemberRole.ADMIN) {
+            throwError(ErrorType.ADMIN_ACCESS_DENIED)
+        }
+
+        post.hide()
+    }
+
+    @Transactional(readOnly = true)
+    fun getTopPosts(): List<PostSummaryResponse> {
+        val sevenDaysAgo = Instant.now().minus(7, ChronoUnit.DAYS)
+
+        val slice = postRepository.findSlice(PageRequest.of(0, 3)) {
+            select(
+                entity(Post::class)
+            ).from(
+                entity(Post::class),
+                fetchJoin(Post::author),
+            ).whereAnd(
+                path(Post::status).eq(PostStatus.PUBLISHED),
+                path(Post::createdAt).greaterThanOrEqualTo(sevenDaysAgo),
+            ).orderBy(
+                path(Post::statistics).path(PostStatistics::score).desc()
+            )
+        }
+
+        return slice.content.map { it.toSummaryResponse() }
+    }
+
+    private fun Post.toSummaryResponse() = PostSummaryResponse(
+        id = requireNotNull(this.id),
+        type = this.type,
+        title = this.title,
+        authorNickname = this.author.nickname,
+        status = this.status,
+        viewCount = this.statistics.viewCount,
+        reactionCount = this.statistics.reactionCount,
+        commentCount = this.statistics.commentCount,
+        isPopular = this.isPopular,
+        createdAt = this.createdAt,
+    )
+
+    private fun Post.toDetailResponse() = PostDetailResponse(
+        id = requireNotNull(this.id),
+        type = this.type,
+        language = this.language,
+        country = this.country,
+        title = this.title,
+        content = this.content,
+        authorNickname = this.author.nickname,
+        authorProfileImageUrl = this.author.profileImageUrl,
+        status = this.status,
+        viewCount = this.statistics.viewCount,
+        reactionCount = this.statistics.reactionCount,
+        commentCount = this.statistics.commentCount,
+        score = this.statistics.score,
+        isPopular = this.isPopular,
+        useReply = this.useReply,
+        isHtml = this.isHtml,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+    )
+}

--- a/src/main/kotlin/com/elseeker/community/application/service/ReactionService.kt
+++ b/src/main/kotlin/com/elseeker/community/application/service/ReactionService.kt
@@ -1,0 +1,62 @@
+package com.elseeker.community.application.service
+
+import com.elseeker.common.domain.ErrorType
+import com.elseeker.common.domain.throwError
+import com.elseeker.community.adapter.output.jpa.PostReactionRepository
+import com.elseeker.community.adapter.output.jpa.PostRepository
+import com.elseeker.community.domain.model.PostReaction
+import com.elseeker.community.domain.vo.PostStatus
+import com.elseeker.community.domain.vo.ReactionType
+import com.elseeker.member.adapter.output.jpa.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class ReactionService(
+    private val postReactionRepository: PostReactionRepository,
+    private val postRepository: PostRepository,
+    private val memberRepository: MemberRepository,
+) {
+
+    @Transactional
+    fun addReaction(postId: Long, memberUid: UUID, type: ReactionType) {
+        val post = postRepository.findByIdAndStatusNot(postId, PostStatus.DELETED)
+            ?: throwError(ErrorType.POST_NOT_FOUND, "postId=$postId")
+
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        val memberId = requireNotNull(member.id)
+
+        if (postReactionRepository.existsByPostIdAndMemberIdAndType(postId, memberId, type)) {
+            throwError(ErrorType.REACTION_ALREADY_EXISTS, "postId=$postId", "type=$type")
+        }
+
+        val reaction = PostReaction.create(
+            post = post,
+            member = member,
+            type = type,
+        )
+        postReactionRepository.save(reaction)
+
+        postRepository.incrementReactionCount(postId)
+        postRepository.updateScore(postId)
+    }
+
+    @Transactional
+    fun removeReaction(postId: Long, memberUid: UUID, type: ReactionType) {
+        val member = memberRepository.findByUid(memberUid)
+            ?: throwError(ErrorType.MEMBER_NOT_FOUND)
+
+        val memberId = requireNotNull(member.id)
+
+        val reaction = postReactionRepository.findByPostIdAndMemberIdAndType(postId, memberId, type)
+            ?: throwError(ErrorType.REACTION_NOT_FOUND, "postId=$postId", "type=$type")
+
+        postReactionRepository.delete(reaction)
+
+        postRepository.decrementReactionCount(postId)
+        postRepository.updateScore(postId)
+    }
+}

--- a/src/main/kotlin/com/elseeker/community/domain/model/Comment.kt
+++ b/src/main/kotlin/com/elseeker/community/domain/model/Comment.kt
@@ -1,0 +1,45 @@
+package com.elseeker.community.domain.model
+
+import com.elseeker.common.domain.BaseTimeEntity
+import com.elseeker.member.domain.model.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "community_comment")
+class Comment(
+
+    id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    val author: Member,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String,
+
+    @Column(nullable = false)
+    var deleted: Boolean = false,
+
+) : BaseTimeEntity(id = id) {
+
+    companion object {
+        fun create(
+            post: Post,
+            author: Member,
+            content: String,
+        ) = Comment(
+            post = post,
+            author = author,
+            content = content,
+        )
+    }
+
+    fun softDelete() {
+        this.deleted = true
+        this.content = ""
+    }
+}

--- a/src/main/kotlin/com/elseeker/community/domain/model/PostReaction.kt
+++ b/src/main/kotlin/com/elseeker/community/domain/model/PostReaction.kt
@@ -1,0 +1,47 @@
+package com.elseeker.community.domain.model
+
+import com.elseeker.common.domain.BaseTimeEntity
+import com.elseeker.community.domain.vo.ReactionType
+import com.elseeker.member.domain.model.Member
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "community_post_reaction",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_post_reaction_member_type",
+            columnNames = ["post_id", "member_id", "reaction_type"]
+        )
+    ]
+)
+class PostReaction(
+
+    id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: Member,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type", nullable = false, length = 10)
+    val type: ReactionType,
+
+) : BaseTimeEntity(id = id) {
+
+    companion object {
+        fun create(
+            post: Post,
+            member: Member,
+            type: ReactionType,
+        ) = PostReaction(
+            post = post,
+            member = member,
+            type = type,
+        )
+    }
+}

--- a/src/main/kotlin/com/elseeker/community/domain/vo/PostStatistics.kt
+++ b/src/main/kotlin/com/elseeker/community/domain/vo/PostStatistics.kt
@@ -9,7 +9,7 @@ data class PostStatistics private constructor(
     var viewCount: Long = 0,
 
     @Column(nullable = false)
-    var likeCount: Long = 0,
+    var reactionCount: Long = 0,
 
     @Column(nullable = false)
     var commentCount: Long = 0,
@@ -23,7 +23,7 @@ data class PostStatistics private constructor(
     companion object {
         fun create() = PostStatistics(
             viewCount = 0,
-            likeCount = 0,
+            reactionCount = 0,
             commentCount = 0,
             reportCount = 0,
             score = 0

--- a/src/main/kotlin/com/elseeker/community/domain/vo/ReactionType.kt
+++ b/src/main/kotlin/com/elseeker/community/domain/vo/ReactionType.kt
@@ -1,0 +1,5 @@
+package com.elseeker.community.domain.vo
+
+enum class ReactionType {
+    LIKE, PRAY
+}


### PR DESCRIPTION
- PostStatistics.likeCount를 reactionCount로 변경 (LIKE/PRAY 합산)
- Line Kotlin JDSL 3.5.5 의존성 추가 및 동적 쿼리 구현
- PostRepository: JDSL 기반 Slice/Page 조회, JPQL 조회수/반응수 배치 update
- PostService: 클라이언트 Slice / 관리자 Page 목록 분리, 상세 조회 시 조회수 증가
- ReactionService: 반응 추가/취소 및 reactionCount 증감
- CommentService: 댓글 조회(Slice) / 작성 및 commentCount 증가
- PostReaction, Comment 엔티티 추가 (soft delete, unique constraint)
- CommunityApi 컨트롤러 + Swagger ApiDocument 인터페이스
- SecurityConfig: 커뮤니티 읽기 API permitAll, 관리자 API ADMIN 권한
- 주간 인기글 Top 3 조회 (score 기반, DB LIMIT 적용)

https://claude.ai/code/session_01G974CD6o4rwKCEZhTijFz1