### PR TITLE
fix: left-align admin card values on mobile

### DIFF
--- a/src/main/resources/static/css/admin/admin.css
+++ b/src/main/resources/static/css/admin/admin.css
@@ -358,6 +358,9 @@ body.admin-sidebar-open {
     .admin-card-actions {
         justify-content: flex-end;
     }
+    .admin-card-value {
+        text-align: left;
+    }
     .admin-table-wrapper {
         display: none;
     }


### PR DESCRIPTION
### Motivation
- Improve mobile readability by left-aligning admin card values which were previously right-aligned on narrow screens.

### Description
- Added a responsive rule in `src/main/resources/static/css/admin/admin.css` under `@media (max-width: 768px)` to set `.admin-card-value { text-align: left; }`.

### Testing
- Attempted to run `./gradlew bootRun` but it failed with `org.gradle.wrapper.GradleWrapperMain` missing, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69869b600aac833095cfa0255a69c6ee)