### PR TITLE
feat: add community feed loading spinner

### DIFF
--- a/src/main/resources/static/css/community/community.css
+++ b/src/main/resources/static/css/community/community.css
@@ -449,6 +449,23 @@ body {
     font-size: 0.9rem;
     color: var(--comm-text-sub);
     padding: 1.5rem 0 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.feed-loader .spinner {
+    width: 20px;
+    height: 20px;
+    border-radius: 999px;
+    border: 2px solid rgba(120, 120, 140, 0.2);
+    border-top-color: var(--comm-primary);
+    animation: spin 0.8s linear infinite;
+}
+
+.feed-loader .loader-text {
+    line-height: 1.4;
 }
 
 .feed-sentinel {
@@ -474,6 +491,12 @@ body {
     to {
         opacity: 1;
         transform: translateY(0);
+    }
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
     }
 }
 

--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -61,7 +61,10 @@
                         <div class="empty-icon">📭</div>
                         <p class="empty-text">아직 등록된 글이 없습니다<br>첫 번째 글을 작성해보세요!</p>
                     </div>
-                    <div id="feedLoader" class="feed-loader" hidden>게시글을 불러오는 중...</div>
+                    <div id="feedLoader" class="feed-loader" hidden>
+                        <span class="spinner" aria-hidden="true"></span>
+                        <span class="loader-text">게시글을 불러오는 중...</span>
+                    </div>
                     <div id="feedSentinel" class="feed-sentinel" aria-hidden="true"></div>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Improve UX by showing a visual loading indicator while community feed posts are being fetched so users know data is loading.

### Description
- Added a loader element with a spinner and text to the feed area in `src/main/resources/templates/community/community.html`.
- Implemented CSS for the spinner, alignment, and animation (including `@keyframes spin`) in `src/main/resources/static/css/community/community.css`.
- Kept the existing loader `id` (`feedLoader`) so existing JS (`App.setLoaderVisible`) continues to toggle visibility.

### Testing
- No automated tests were run because this is a frontend-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6987efa22dd88330a8021a6f3dcddb9d)