### PR TITLE
fix: use shared spinner for community feed loader

### DIFF
--- a/src/main/resources/static/css/community/community.css
+++ b/src/main/resources/static/css/community/community.css
@@ -445,27 +445,13 @@ body {
 }
 
 .feed-loader {
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--comm-text-sub);
     padding: 1.5rem 0 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-}
-
-.feed-loader .spinner {
-    width: 20px;
-    height: 20px;
-    border-radius: 999px;
-    border: 2px solid rgba(120, 120, 140, 0.2);
-    border-top-color: var(--comm-primary);
-    animation: spin 0.8s linear infinite;
 }
 
 .feed-loader .loader-text {
     line-height: 1.4;
+    font-size: 0.95rem;
+    color: var(--comm-text-sub);
 }
 
 .feed-sentinel {

--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -62,8 +62,10 @@
                         <p class="empty-text">아직 등록된 글이 없습니다<br>첫 번째 글을 작성해보세요!</p>
                     </div>
                     <div id="feedLoader" class="feed-loader" hidden>
-                        <span class="spinner" aria-hidden="true"></span>
-                        <span class="loader-text">게시글을 불러오는 중...</span>
+                        <div class="spinner-container">
+                            <div class="custom-spinner" aria-hidden="true"></div>
+                            <p class="loader-text">게시글을 불러오는 중입니다...</p>
+                        </div>
                     </div>
                     <div id="feedSentinel" class="feed-sentinel" aria-hidden="true"></div>
                 </div>


### PR DESCRIPTION
### Motivation
- Replace the bespoke community feed loader UI with the app-wide spinner component so loading states are visually consistent with other pages like `bible-quiz-map.html`.

### Description
- Updated `src/main/resources/templates/community/community.html` to use the shared spinner markup (`.spinner-container` / `.custom-spinner`) and adjusted the loading text to `게시글을 불러오는 중입니다...`.
- Simplified `src/main/resources/static/css/community/community.css` by removing the local spinner rules and aligning the loader text styling to use existing common variables.

### Testing
- No automated tests were run because this is a frontend-only change per repository guidelines; changes were validated by inspecting templates and CSS edits locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698800139ac08330b13fd10cfd901d9e)