### PR TITLE
fix: hide community empty state during loading

### DIFF
--- a/src/main/resources/static/js/community/community.js
+++ b/src/main/resources/static/js/community/community.js
@@ -227,8 +227,8 @@ const App = {
         }
 
         if (!append) {
-            App.setEmptyState(true, "게시글을 불러오는 중입니다...");
             App.clearFeed();
+            App.setEmptyState(false);
         }
         App.setLoaderVisible(true);
         App.state.isLoading = true;


### PR DESCRIPTION
### Motivation
- Prevent the empty-state panel (icon + message) from appearing together with the loader so that only the spinner is visible while community posts are being fetched.

### Description
- In `src/main/resources/static/js/community/community.js` changed the non-append load behavior in `loadPosts` to call `App.setEmptyState(false)` (hide empty panel) and `App.clearFeed()` when starting a load instead of showing the empty-state message.

### Testing
- No automated tests were run for this frontend-only change; an attempt to launch locally with `./gradlew bootRun` failed with `ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain`, so UI verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6988046db47c83308bae2f40b356f97d)