### PR TITLE
fix: keep quiz map connectors outside cards

### DIFF
--- a/src/main/resources/static/css/game/bible-quiz-map.css
+++ b/src/main/resources/static/css/game/bible-quiz-map.css
@@ -354,14 +354,14 @@
 .stage-card:not(:last-child)::after {
     content: '';
     position: absolute;
-    bottom: -3.5rem;
-    /* Extend into gap (gap is 3rem + padding) */
+    bottom: -3rem;
+    /* Start right at the card edge to avoid overlap */
     left: 50%;
     transform: translateX(-50%);
     width: 3px;
     /* Line thickness */
-    height: 4rem;
-    /* Should bridge the gap */
+    height: 3rem;
+    /* Match the grid gap so it doesn't enter the next card */
     background: repeating-linear-gradient(to bottom,
             var(--flow-color),
             var(--flow-color) 8px,
@@ -408,7 +408,7 @@
         /* Change from absolute positioning relative to self to create bridge */
         position: absolute;
         top: 50%;
-        right: -2rem;
+        right: calc(-2rem - 2px);
         /* Matches horizontal gap approximately */
         width: 2rem;
         /* Bridge the gap */
@@ -430,7 +430,7 @@
         display: block;
         position: absolute;
         top: 50%;
-        left: -2rem;
+        left: calc(-2rem - 2px);
         width: 2rem;
         height: 3px;
         background: repeating-linear-gradient(to right,


### PR DESCRIPTION
### Motivation
- Prevent the dashed connector lines on the bible quiz map from intruding into the stage card areas on both mobile (vertical) and desktop (horizontal) layouts.

### Description
- Adjusted vertical connector positioning so the pseudo-element starts at the card edge by changing `bottom` from `-3.5rem` to `-3rem` and `height` from `4rem` to `3rem` in `src/main/resources/static/css/game/bible-quiz-map.css`.
- Nudged horizontal connectors outward on desktop by changing `right`/`left` offsets to `calc(-2rem - 2px)` so dashed lines remain outside card borders.
- Kept connector styling behavior for `.is-complete` and `.is-current` while matching connector lengths to grid gaps for consistent spacing.

### Testing
- No automated unit/integration tests were executed because this is a frontend-only CSS change following project guidelines.
- Attempted to run `gradle bootRun` for a visual check, but it failed with `BUILD FAILED` (error shown as `25.0.1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69887bbe35a883309b37dd04fc134713)