### PR TITLE
fix: preserve book description line breaks

### DIFF
--- a/src/main/resources/static/css/bible/book-description.css
+++ b/src/main/resources/static/css/bible/book-description.css
@@ -1,0 +1,3 @@
+.book-description-text {
+    white-space: pre-line;
+}

--- a/src/main/resources/templates/bible/book-description.html
+++ b/src/main/resources/templates/bible/book-description.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('책 개요 | ElSeeker', true, null)}"
+<head th:replace="~{fragments/head :: head('책 개요 | ElSeeker', true, '/css/bible/book-description.css?v=1.0')}"
       th:with="pageDescription='성경 각 책의 개요, 저자, 기록 시기와 배경을 요약해 안내합니다.'"></head>
 
 <body class="has-fixed-nav">
@@ -28,11 +28,11 @@
         </p>
         <p>
             <strong id="backgroundLabel"></strong><br>
-            <span id="background"></span>
+            <span id="background" class="book-description-text"></span>
         </p>
         <p>
             <strong id="contentLabel"></strong><br>
-            <span id="content"></span>
+            <span id="content" class="book-description-text"></span>
         </p>
     </div>
 </main>


### PR DESCRIPTION
### Motivation
- Preserve newline formatting for the `background` and `content` spans on the book description page so multi-line descriptions render with line breaks.

### Description
- Add `src/main/resources/static/css/bible/book-description.css` with `.book-description-text { white-space: pre-line; }` to enable newline rendering.
- Include the new stylesheet in the `book-description.html` head via the `fragments/head` call and add `class="book-description-text"` to the `#background` and `#content` spans.

### Testing
- Frontend-only change; per project guidelines `./gradlew build`/`./gradlew test` were not run and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989adfe06f08330a6b915124ef36aba)