### PR TITLE
feat: remove hero section and use shared header title for casting lots

### DIFF
--- a/src/main/resources/templates/game/bible-casting-lots.html
+++ b/src/main/resources/templates/game/bible-casting-lots.html
@@ -1,19 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 제비뽑기 | ElSeeker', true, '/css/hero.css?v=2.3,/css/card.css?v=2.3,/css/game/bible-casting-lots.css?v=1.0')}"></head>
+<head th:replace="~{fragments/head :: head('성경 제비뽑기 | ElSeeker', true, '/css/card.css?v=2.3,/css/game/bible-casting-lots.css?v=1.0')}"></head>
 <body class="has-fixed-nav" data-back-link="/web/game">
 <header th:replace="~{fragments/header :: header}"
-        th:with="pageTitle='성경 제비뽑기', pageTitleVisible=true"></header>
+        th:with="pageTitle='제비뽑기', pageTitleVisible=true"></header>
 
 <main class="container content-wrapper casting-lots-page" data-stage="SETUP">
-    <section class="casting-lots-hero">
-        <p class="casting-lots-eyebrow">묵상 · 나눔</p>
-        <h1 class="casting-lots-title">제비뽑기 (Casting Lots)</h1>
-        <p class="casting-lots-lead">
-            말씀을 나누기 위한 역할, 오늘의 주제, 감사 제목을 제비로 나누어 보세요.
-        </p>
-    </section>
-
     <section class="casting-lots-progress" aria-label="진행 단계">
         <ol class="casting-lots-steps">
             <li class="casting-lots-step" data-stage="SETUP">


### PR DESCRIPTION
### Motivation
- Simplify the casting lots screen by removing the page-specific hero area and surface the screen name in the shared header so the page title is consistent with other screens.

### Description
- Removed the `.casting-lots-hero` markup, removed the hero stylesheet from the head include, and set the shared header `pageTitle` to `제비뽑기` in `src/main/resources/templates/game/bible-casting-lots.html`.

### Testing
- No automated tests were run because this is a frontend-only template change per the repository guideline, and an attempted `./gradlew bootRun` failed with `org.gradle.wrapper.GradleWrapperMain` not found so the application could not be started for a manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a78b45a788330a6bb147ed27c6e2f)