### PR TITLE
feat: flip lot cards to show results

### DIFF
--- a/src/main/resources/static/js/game/bible-casting-lots.js
+++ b/src/main/resources/static/js/game/bible-casting-lots.js
@@ -9,8 +9,9 @@ const STAGES = Object.freeze({
 const state = {
     stage: STAGES.SETUP,
     lots: [],
-    results: [],
 };
+
+const DEFAULT_RESULT_MESSAGE = "제비 결과는 카드가 뒤집히면서 바로 확인됩니다.";
 
 const elements = {
     page: document.querySelector(".casting-lots-page"),
@@ -24,7 +25,6 @@ const elements = {
     remaining: document.getElementById("remainingLots"),
     cardGrid: document.getElementById("lotCardGrid"),
     resultSection: document.getElementById("castingResultSection"),
-    resultList: document.getElementById("resultList"),
     resultMessage: document.getElementById("castingResultMessage"),
     resultComplete: document.getElementById("resultComplete"),
     resetButton: document.getElementById("resetLotsButton"),
@@ -120,18 +120,6 @@ const renderCards = () => {
     elements.remaining.textContent = String(state.lots.filter((lot) => !lot.revealed).length);
 };
 
-const renderResults = () => {
-    elements.resultList.innerHTML = "";
-    state.results.forEach((result, index) => {
-        const item = document.createElement("li");
-        item.className = "result-item";
-        item.innerHTML = `<span>${index + 1}번째 제비</span>${result}`;
-        elements.resultList.appendChild(item);
-    });
-
-    elements.resultComplete.classList.toggle("d-none", state.lots.some((lot) => !lot.revealed));
-};
-
 const startShuffle = () => {
     elements.deckMessage.textContent = "제비를 섞고 있어요...";
     setStage(STAGES.SHUFFLED);
@@ -165,8 +153,8 @@ const handleFoldLots = () => {
             revealed: false,
         }))
     );
-    state.results = [];
-    renderResults();
+    elements.resultMessage.textContent = DEFAULT_RESULT_MESSAGE;
+    elements.resultComplete.classList.add("d-none");
     startShuffle();
 };
 
@@ -179,14 +167,13 @@ const handleCardClick = (event) => {
     if (!lot || lot.revealed) return;
 
     lot.revealed = true;
-    state.results.push(lot.text);
 
     card.classList.add("is-revealed");
     card.disabled = true;
     card.setAttribute("aria-label", "펼쳐진 제비");
 
     elements.remaining.textContent = String(state.lots.filter((item) => !item.revealed).length);
-    renderResults();
+    elements.resultComplete.classList.toggle("d-none", state.lots.some((item) => !item.revealed));
 
     if (state.lots.every((item) => item.revealed)) {
         elements.deckMessage.textContent = "모든 제비를 펼쳤습니다.";
@@ -198,10 +185,9 @@ const handleCardClick = (event) => {
 const resetGame = () => {
     state.stage = STAGES.SETUP;
     state.lots = [];
-    state.results = [];
-    elements.resultList.innerHTML = "";
     elements.cardGrid.innerHTML = "";
     elements.resultComplete.classList.add("d-none");
+    elements.resultMessage.textContent = DEFAULT_RESULT_MESSAGE;
     buildInputRows(elements.countInput.value);
     setStage(STAGES.SETUP);
 };

--- a/src/main/resources/templates/game/bible-casting-lots.html
+++ b/src/main/resources/templates/game/bible-casting-lots.html
@@ -65,12 +65,11 @@
 
     <section class="casting-lots-section casting-lots-result d-none" id="castingResultSection">
         <div class="section-header">
-            <h2 class="section-title">결과 요약</h2>
+            <h2 class="section-title">결과 안내</h2>
             <p class="section-description" id="castingResultMessage">
-                펼쳐진 제비가 아래에 순서대로 기록됩니다.
+                제비 결과는 카드가 뒤집히면서 바로 확인됩니다.
             </p>
         </div>
-        <ol class="result-list" id="resultList"></ol>
         <div class="result-complete d-none" id="resultComplete">
             <strong>제비뽑기 완료</strong>
             <p class="mb-0">모든 제비를 확인했습니다.</p>


### PR DESCRIPTION
### Motivation
- Change the casting-lots UX so clicking a lot card flips the card to reveal its result instead of appending the result to a summary list.
- Simplify the result presentation and make the card itself the primary result affordance.
- Keep the experience immediate and tactile by resetting result guidance text on new rounds.

### Description
- Updated `src/main/resources/templates/game/bible-casting-lots.html` to remove the result list and change the result section copy to instruct users that results appear on flipped cards.
- Removed the results list and `results` state from `src/main/resources/static/js/game/bible-casting-lots.js` and stopped pushing revealed items into a separate summary array.
- Added `DEFAULT_RESULT_MESSAGE` and wired the message to be reset on fold/reset so the UI guides the user to flip cards for results.
- Adjusted visibility toggles so the existing card flip CSS (`.is-revealed`) and `resultComplete` indicator are used to reflect progress instead of a separate list render.

### Testing
- No automated build/test run was performed because this is a frontend-only change and repository guidelines recommend not running `./gradlew build` for such changes.
- I attempted to run `./gradlew bootRun` to visually verify the change, but it failed with `ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain` so a local run/screenshot could not be produced.
- All changes are limited to `src/main/resources/templates/game/bible-casting-lots.html` and `src/main/resources/static/js/game/bible-casting-lots.js` and were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a7b97bca88330a10464bb84975e05)