### PR TITLE
feat: 성경책 목록 구약/신약 섹션 접기/펼치기 기능 추가

### DIFF
--- a/src/main/resources/static/css/bible/book-list.css
+++ b/src/main/resources/static/css/bible/book-list.css
@@ -42,12 +42,49 @@
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 0.75rem;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .book-section-header:hover .book-section-title {
+        color: #495057;
+    }
+}
+
+.book-section-header[aria-expanded="false"] {
+    margin-bottom: 0;
+}
+
+.book-section-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.book-section-chevron {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #868e96;
+    transition: transform 0.25s ease;
+    flex-shrink: 0;
+}
+
+.book-section-header[aria-expanded="false"] .book-section-chevron {
+    transform: rotate(-90deg);
 }
 
 .book-section-title {
     font-size: 1.25rem;
     font-weight: 700;
     margin: 0;
+    transition: color 0.2s;
 }
 
 .book-section-count {
@@ -56,4 +93,13 @@
     background-color: #f1f3f5;
     padding: 0.2rem 0.65rem;
     border-radius: 999px;
+}
+
+.book-section-body {
+    overflow: hidden;
+    transition: grid-template-rows 0.3s ease;
+}
+
+.book-section-body.collapsed {
+    display: none;
 }

--- a/src/main/resources/static/js/bible/book-list.js
+++ b/src/main/resources/static/js/bible/book-list.js
@@ -1,7 +1,12 @@
 import {BookStore, TranslationStore} from "/js/storage-util.js?v=2.2";
 
 const UI_CLASSES = {
-    HIDDEN: "d-none"
+    HIDDEN: "d-none",
+    COLLAPSED: "collapsed"
+};
+
+const STORAGE_KEYS = {
+    SECTION_STATE: "bookList_sectionState"
 };
 
 const API_CONFIG = {
@@ -24,9 +29,57 @@ const DomHelper = {
             pageTitleLabel: get("pageTitleLabel"),
             oldTestamentList: get("oldTestamentList"),
             oldTestamentCount: get("oldTestamentCount"),
+            oldTestamentToggle: get("oldTestamentToggle"),
             newTestamentList: get("newTestamentList"),
-            newTestamentCount: get("newTestamentCount")
+            newTestamentCount: get("newTestamentCount"),
+            newTestamentToggle: get("newTestamentToggle")
         };
+    }
+};
+
+const SectionToggle = {
+    loadState: () => {
+        try {
+            const raw = sessionStorage.getItem(STORAGE_KEYS.SECTION_STATE);
+            return raw ? JSON.parse(raw) : {};
+        } catch {
+            return {};
+        }
+    },
+
+    saveState: state => {
+        sessionStorage.setItem(STORAGE_KEYS.SECTION_STATE, JSON.stringify(state));
+    },
+
+    isExpanded: sectionKey => {
+        const state = SectionToggle.loadState();
+        return state[sectionKey] !== false;
+    },
+
+    toggle: sectionKey => {
+        const state = SectionToggle.loadState();
+        const currentlyExpanded = state[sectionKey] !== false;
+        state[sectionKey] = !currentlyExpanded;
+        SectionToggle.saveState(state);
+        return !currentlyExpanded;
+    },
+
+    apply: (toggleButton, bodyElement, expanded) => {
+        if (!toggleButton || !bodyElement) return;
+        toggleButton.setAttribute("aria-expanded", String(expanded));
+        bodyElement.classList.toggle(UI_CLASSES.COLLAPSED, !expanded);
+    },
+
+    init: (toggleButton, bodyElement, sectionKey) => {
+        if (!toggleButton || !bodyElement) return;
+
+        const expanded = SectionToggle.isExpanded(sectionKey);
+        SectionToggle.apply(toggleButton, bodyElement, expanded);
+
+        toggleButton.addEventListener("click", () => {
+            const newExpanded = SectionToggle.toggle(sectionKey);
+            SectionToggle.apply(toggleButton, bodyElement, newExpanded);
+        });
     }
 };
 
@@ -39,6 +92,7 @@ const App = {
     init: async () => {
         App.elements = DomHelper.getElements();
         App.initNav();
+        App.initSectionToggles();
 
         App.state.translationId = App.getTranslationId();
         if (!App.state.translationId) {
@@ -68,6 +122,11 @@ const App = {
         if (pageTitleLabel) {
             pageTitleLabel.classList.remove(UI_CLASSES.HIDDEN);
         }
+    },
+
+    initSectionToggles: () => {
+        SectionToggle.init(App.elements.oldTestamentToggle, App.elements.oldTestamentList, "old");
+        SectionToggle.init(App.elements.newTestamentToggle, App.elements.newTestamentList, "new");
     },
 
     getTranslationId: () => {

--- a/src/main/resources/templates/bible/book-list.html
+++ b/src/main/resources/templates/bible/book-list.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경책 목록 | ElSeeker', true, '/css/bible/book-list.css?v=2.2')}"
+<head th:replace="~{fragments/head :: head('성경책 목록 | ElSeeker', true, '/css/bible/book-list.css?v=2.3')}"
       th:with="pageDescription='선택한 번역본의 구약과 신약 66권을 한눈에 살펴볼 수 있는 성경책 목록입니다.'"></head>
 <body class="has-fixed-nav">
 
@@ -10,22 +10,34 @@
 <main class="container content-wrapper">
     <div class="book-sections">
         <section class="book-section" aria-labelledby="oldTestamentTitle">
-            <div class="book-section-header">
-                <h2 id="oldTestamentTitle" class="book-section-title">구약</h2>
+            <button type="button" class="book-section-header" id="oldTestamentToggle"
+                    aria-expanded="true" aria-controls="oldTestamentList">
+                <div class="book-section-header-left">
+                    <svg class="book-section-chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/>
+                    </svg>
+                    <h2 id="oldTestamentTitle" class="book-section-title">구약</h2>
+                </div>
                 <span id="oldTestamentCount" class="book-section-count"></span>
-            </div>
-            <div id="oldTestamentList" class="book-grid"></div>
+            </button>
+            <div id="oldTestamentList" class="book-grid book-section-body"></div>
         </section>
         <section class="book-section" aria-labelledby="newTestamentTitle">
-            <div class="book-section-header">
-                <h2 id="newTestamentTitle" class="book-section-title">신약</h2>
+            <button type="button" class="book-section-header" id="newTestamentToggle"
+                    aria-expanded="true" aria-controls="newTestamentList">
+                <div class="book-section-header-left">
+                    <svg class="book-section-chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/>
+                    </svg>
+                    <h2 id="newTestamentTitle" class="book-section-title">신약</h2>
+                </div>
                 <span id="newTestamentCount" class="book-section-count"></span>
-            </div>
-            <div id="newTestamentList" class="book-grid"></div>
+            </button>
+            <div id="newTestamentList" class="book-grid book-section-body"></div>
         </section>
     </div>
 </main>
 
-<script type="module" src="/js/bible/book-list.js?v=2.2"></script>
+<script type="module" src="/js/bible/book-list.js?v=2.3"></script>
 </body>
 </html>


### PR DESCRIPTION
- 섹션 헤더를 클릭 가능한 버튼으로 변경하고 chevron 아이콘 추가
- sessionStorage로 접기/펼치기 상태 유지
- aria-expanded, aria-controls 접근성 속성 적용
- 데스크톱 전용 hover 스타일 및 chevron 회전 애니메이션 적용

https://claude.ai/code/session_018dNoesyCGWNzb73xVd7B9r