### PR TITLE
fix: 사도신경 history 섹션이 브라우저 캐시로 인해 표시되지 않는 문제 수정

### DIFF
--- a/src/main/resources/templates/study/apostles-creed.html
+++ b/src/main/resources/templates/study/apostles-creed.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('사도신경 | ElSeeker', true, '/css/search.css?v=2.2,/css/card.css?v=2.2,/css/study/apostles-creed.css?v=1.0')}"></head>
+<head th:replace="~{fragments/head :: head('사도신경 | ElSeeker', true, '/css/search.css?v=2.2,/css/card.css?v=2.2,/css/study/apostles-creed.css?v=1.1')}"></head>
 <body class="has-fixed-nav">
 
 <header th:replace="~{fragments/header :: header}"></header>
@@ -24,6 +24,6 @@
 
 <button id="scrollToTopBtn" class="scroll-to-top-btn" type="button" aria-label="맨 위로 이동">↑</button>
 
-<script type="module" src="/js/study/apostles-creed.js?v=1.0"></script>
+<script type="module" src="/js/study/apostles-creed.js?v=1.1"></script>
 </body>
 </html>


### PR DESCRIPTION
사도신경 페이지에 '유래와 역사' 섹션을 추가한 커밋(07f424b)에서
JS/CSS 캐시 버스팅 버전 문자열을 갱신하지 않아, 이전 버전을 캐시한
브라우저에서 history 데이터가 렌더링되지 않는 문제를 수정한다.
apostles-creed.css와 apostles-creed.js의 버전을 v=1.0에서 v=1.1로 변경한다.

https://claude.ai/code/session_016gcqDCqU2PFiz16v875RsS