### PR TITLE
사도신경 history 섹션 디자인을 주기도문 패턴에 맞춰 업데이트

### DIFF
--- a/src/main/resources/static/css/study/apostles-creed.css
+++ b/src/main/resources/static/css/study/apostles-creed.css
@@ -36,38 +36,46 @@
     line-height: 2;
 }
 
-/* History Section */
+/* History */
 .apostles-creed-history {
     max-width: 720px;
     margin: 0 auto 2rem;
 }
 
 .apostles-creed-history-inner {
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
+    background: linear-gradient(145deg, #fef3c7 0%, #fde68a 100%);
+    border: 1px solid #f59e0b;
     border-radius: 0.75rem;
-    padding: 1.5rem 1.75rem;
+    padding: 1.75rem 2rem;
 }
 
 .apostles-creed-history-title {
-    font-size: 1rem;
+    font-size: 1.15rem;
     font-weight: 700;
-    color: #1e3a5f;
-    margin: 0 0 1rem;
-    padding-bottom: 0.65rem;
-    border-bottom: 1px solid #e2e8f0;
+    color: #78350f;
+    margin: 0 0 1.25rem;
+    text-align: center;
 }
 
-.apostles-creed-history-body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.apostles-creed-history-section {
+    margin-bottom: 0.85rem;
 }
 
-.apostles-creed-history-body p {
+.apostles-creed-history-section:last-child {
+    margin-bottom: 0;
+}
+
+.apostles-creed-history-section-title {
     font-size: 0.85rem;
-    color: #475569;
-    line-height: 1.75;
+    font-weight: 700;
+    color: #92400e;
+    margin: 0 0 0.25rem;
+}
+
+.apostles-creed-history-section-body {
+    font-size: 0.85rem;
+    color: #451a03;
+    line-height: 1.7;
     margin: 0;
 }
 
@@ -77,11 +85,7 @@
     }
 
     .apostles-creed-history-title {
-        font-size: 0.95rem;
-    }
-
-    .apostles-creed-history-body p {
-        font-size: 0.8rem;
+        font-size: 1.05rem;
     }
 }
 

--- a/src/main/resources/static/js/study/apostles-creed.js
+++ b/src/main/resources/static/js/study/apostles-creed.js
@@ -123,15 +123,24 @@ const FULL_CREED_TEXT = `나는 전능하신 아버지 하나님,
 영생을 믿습니다.
 아멘.`;
 
-const CREED_HISTORY = {
-    title: "사도신경의 유래와 역사",
-    paragraphs: [
-        "사도신경(Symbolum Apostolorum)은 성경 정경이 아니라 초대교회의 신앙고백문이다. 그 기원은 2세기경 로마 교회의 세례 문답에서 사용된 '로마 신조'(Romanum)로 거슬러 올라간다.",
-        "이후 영지주의, 마르키온주의 등 이단에 대응하는 과정에서 삼위일체 구조의 고백 문구가 점차 구체화되었다.",
-        "현재 전해지는 형태(Textus Receptus)는 7~8세기 서방교회, 특히 갈리아 지역에서 확정된 것으로, 피르미니우스의 저술(약 750년)에 처음 완전한 본문이 등장한다.",
-        "'열두 사도가 각각 한 조항씩 작성했다'는 전승은 4~5세기 이후에 형성된 것으로, 현대 교회사 학계에서는 역사적 사실로 보지 않는다."
-    ]
-};
+const CREED_HISTORY = [
+    {
+        title: "1. 기원",
+        body: "사도신경(Symbolum Apostolorum)은 성경 정경이 아니라 초대교회의 신앙고백문이다. 그 기원은 2세기경 로마 교회의 세례 문답에서 사용된 '로마 신조'(Romanum)로 거슬러 올라간다."
+    },
+    {
+        title: "2. 이단 대응과 발전",
+        body: "이후 영지주의, 마르키온주의 등 이단에 대응하는 과정에서 삼위일체 구조의 고백 문구가 점차 구체화되었다."
+    },
+    {
+        title: "3. 현재 본문의 확정",
+        body: "현재 전해지는 형태(Textus Receptus)는 7~8세기 서방교회, 특히 갈리아 지역에서 확정된 것으로, 피르미니우스의 저술(약 750년)에 처음 완전한 본문이 등장한다."
+    },
+    {
+        title: "4. 사도 저작설",
+        body: "'열두 사도가 각각 한 조항씩 작성했다'는 전승은 4~5세기 이후에 형성된 것으로, 현대 교회사 학계에서는 역사적 사실로 보지 않는다."
+    }
+];
 
 class ApostlesCreed {
     constructor() {
@@ -198,11 +207,17 @@ class ApostlesCreed {
     }
 
     renderHistory() {
-        const paragraphs = CREED_HISTORY.paragraphs.map(p => `<p>${p}</p>`).join("");
+        const sections = CREED_HISTORY.map(s => `
+            <div class="apostles-creed-history-section">
+                <p class="apostles-creed-history-section-title">${s.title}</p>
+                <p class="apostles-creed-history-section-body">${s.body}</p>
+            </div>
+        `).join("");
+
         this.historyEl.innerHTML = `
             <div class="apostles-creed-history-inner">
-                <h3 class="apostles-creed-history-title">${CREED_HISTORY.title}</h3>
-                <div class="apostles-creed-history-body">${paragraphs}</div>
+                <h3 class="apostles-creed-history-title">사도신경의 유래와 역사</h3>
+                ${sections}
             </div>
         `;
     }

--- a/src/main/resources/templates/study/apostles-creed.html
+++ b/src/main/resources/templates/study/apostles-creed.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('사도신경 | ElSeeker', true, '/css/search.css?v=2.2,/css/card.css?v=2.2,/css/study/apostles-creed.css?v=1.1')}"></head>
+<head th:replace="~{fragments/head :: head('사도신경 | ElSeeker', true, '/css/search.css?v=2.2,/css/card.css?v=2.2,/css/study/apostles-creed.css?v=1.2')}"></head>
 <body class="has-fixed-nav">
 
 <header th:replace="~{fragments/header :: header}"></header>
@@ -24,6 +24,6 @@
 
 <button id="scrollToTopBtn" class="scroll-to-top-btn" type="button" aria-label="맨 위로 이동">↑</button>
 
-<script type="module" src="/js/study/apostles-creed.js?v=1.1"></script>
+<script type="module" src="/js/study/apostles-creed.js?v=1.2"></script>
 </body>
 </html>


### PR DESCRIPTION
- CSS: 플랫 배경을 amber 그라디언트로 변경, 제목 중앙 정렬, 섹션 기반 레이아웃 적용
- JS: CREED_HISTORY 데이터를 {title, body} 배열 구조로 변경, renderHistory에 섹션별 렌더링 적용
- HTML: CSS/JS 캐시 버전 v1.1 → v1.2

https://claude.ai/code/session_01UTEJRLxN2kP4krWtVokToa