### PR TITLE
알림 버튼을 커뮤니티 화면에서만 노출되도록 변경

### DIFF
--- a/src/main/resources/templates/community/community-detail.html
+++ b/src/main/resources/templates/community/community-detail.html
@@ -6,7 +6,8 @@
 </head>
 
 <body class="has-fixed-nav" th:attr="data-post-id=${postId}, data-back-link='/web/community'">
-<header th:replace="~{fragments/header :: header}"></header>
+<header th:replace="~{fragments/header :: header}"
+        th:with="showNotificationButton=true"></header>
 
 <main class="container content-wrapper">
     <div class="community-layout">

--- a/src/main/resources/templates/community/community-write.html
+++ b/src/main/resources/templates/community/community-write.html
@@ -6,7 +6,8 @@
 </head>
 
 <body class="has-fixed-nav" data-back-link="/web/community">
-<header th:replace="~{fragments/header :: header}"></header>
+<header th:replace="~{fragments/header :: header}"
+        th:with="showNotificationButton=true"></header>
 
 <main class="container content-wrapper">
     <div class="write-layout">

--- a/src/main/resources/templates/community/community.html
+++ b/src/main/resources/templates/community/community.html
@@ -8,7 +8,7 @@
 
 <body class="has-fixed-nav">
 <header th:replace="~{fragments/header :: header}"
-        th:with="pageTitle='커뮤니티', pageTitleVisible=true"></header>
+        th:with="pageTitle='커뮤니티', pageTitleVisible=true, showNotificationButton=true"></header>
 
 <main class="container content-wrapper">
     <!-- Feed Section with Category Tabs -->

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -42,7 +42,8 @@
                             class="top-nav-notification-button top-nav-btn btn btn-outline-secondary d-none"
                             aria-label="알림"
                             title="알림"
-                            disabled>
+                            disabled
+                            th:data-show-notification="${showNotificationButton == true}">
                         🔔
                         <span id="topNavNotificationBadge" class="top-nav-notification-badge d-none"></span>
                     </button>
@@ -120,7 +121,7 @@
                     logoutLink.classList.remove("d-none");
                     myPageLink.classList.remove("d-none");
                     accountDivider.classList.remove("d-none");
-                    if (notificationButton) {
+                    if (notificationButton && notificationButton.dataset.showNotification === "true") {
                         notificationButton.classList.remove("d-none");
                     }
                 },


### PR DESCRIPTION
header fragment에 showNotificationButton Thymeleaf 변수를 추가하여
커뮤니티 페이지(목록, 상세, 글쓰기)에서만 알림 버튼이 표시되도록 제한.
나머지 페이지에서는 data-show-notification이 false로 설정되어 숨김 처리.

https://claude.ai/code/session_01XMVzFGdZpXBKyWYkfua2pV