### PR TITLE
fix: prevent iOS IME duplicate commit and double navigation

### DIFF
--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -129,8 +129,10 @@ function createHiddenInput() {
 
     hiddenInput.addEventListener('compositionend', (e) => {
         isComposing = false;
-        if (e.data) {
-            commitCellInput(e.data.charAt(e.data.length - 1));
+        const committedText = e.data || hiddenInput.value || '';
+        const committedChar = committedText.charAt(committedText.length - 1);
+        if (committedChar) {
+            commitCellInput(committedChar);
             moveToNextCell();
             lastCommitAt = Date.now();
             ignoreNextInput = true;

--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -100,6 +100,9 @@ async function initPuzzle() {
 // ══════════════════════════════════════════
 
 function createHiddenInput() {
+    let ignoreNextInput = false;
+    let lastCommitAt = 0;
+
     hiddenInput = document.createElement('input');
     hiddenInput.className = 'wp-hidden-input';
     hiddenInput.type = 'text';
@@ -120,6 +123,7 @@ function createHiddenInput() {
     // ── IME Composition (한글 조합) ──
     hiddenInput.addEventListener('compositionstart', () => {
         isComposing = true;
+        ignoreNextInput = false;
         hiddenInput.value = '';
     });
 
@@ -127,6 +131,9 @@ function createHiddenInput() {
         isComposing = false;
         if (e.data) {
             commitCellInput(e.data.charAt(e.data.length - 1));
+            moveToNextCell();
+            lastCommitAt = Date.now();
+            ignoreNextInput = true;
         }
         hiddenInput.value = '';
         compositionEndedAt = Date.now();
@@ -140,13 +147,13 @@ function createHiddenInput() {
         const code = e.keyCode;
         setTimeout(() => {
             if (!compositionEndedAt || Date.now() - compositionEndedAt > 300) return;
-            compositionEndedAt = 0;
+            if (key === 'Enter' || code === 13 || key === 'Tab' || code === 9) {
+                compositionEndedAt = 0;
+                return;
+            }
 
-            if (key === 'Enter' || code === 13) {
-                moveToNextCell();
-            } else if (key === 'Tab' || code === 9) {
-                moveToNextEntry(e.shiftKey);
-            } else if (key === ' ' || code === 32) {
+            compositionEndedAt = 0;
+            if (key === ' ' || code === 32) {
                 state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
                 selectCell(state.selectedRow, state.selectedCol);
             }
@@ -163,6 +170,15 @@ function createHiddenInput() {
                     composingText.charAt(composingText.length - 1));
             }
             return;
+        }
+
+        if (ignoreNextInput && Date.now() - lastCommitAt < 120) {
+            ignoreNextInput = false;
+            hiddenInput.value = '';
+            return;
+        }
+        if (ignoreNextInput) {
+            ignoreNextInput = false;
         }
         if (e.inputType === 'insertCompositionText') return;
 

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.3"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.4"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.4"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.5"></script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation
- iOS Safari/Chrome may emit an extra `input` after `compositionend`, causing Hangul jamo to split, duplicate commits, and double cell navigation.
- The goal is to ensure a single commit and a single `moveToNextCell()` after composition end while preserving existing hidden-input pattern and other keyboard behaviors.

### Description
- Added an iOS-focused guard (`ignoreNextInput` + `lastCommitAt`) scoped inside `createHiddenInput()` to suppress the duplicate `input` event immediately after `compositionend`.
- Enforced IME state flags: `isComposing=true` on `compositionstart` and `isComposing=false` on `compositionend` and perform exactly one `commitCellInput(...)` followed by one `moveToNextCell()` in `compositionend`.
- Modified `input` handler to keep composition preview behavior, prevent cell movement from `input`, and ignore the next input if it occurs within a short time window (~120ms) after a composition commit.
- Adjusted `keyup` logic to skip Enter/Tab movement when it occurs right after `compositionend`, while preserving Space direction-toggle behavior.
- Bumped the JS module cache-busting query to `?v=2.4` in the template to ensure clients pick up the fix.

### Testing
- Ran static syntax check with `node --check src/main/resources/static/js/game/bible-word-puzzle-play.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a85b3f2d8083309ec7a42b51407084)