### PR TITLE
Improve Korean IME handling to avoid duplicate input and adjust post-composition key behavior

### DIFF
--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -100,6 +100,10 @@ async function initPuzzle() {
 // ══════════════════════════════════════════
 
 function createHiddenInput() {
+    let ignoreNextInput = false;
+    let lastCommitAt = 0;
+    let skipPostCompositionKeyup = false;
+
     hiddenInput = document.createElement('input');
     hiddenInput.className = 'wp-hidden-input';
     hiddenInput.type = 'text';
@@ -120,37 +124,40 @@ function createHiddenInput() {
     // ── IME Composition (한글 조합) ──
     hiddenInput.addEventListener('compositionstart', () => {
         isComposing = true;
+        ignoreNextInput = false;
         hiddenInput.value = '';
     });
 
     hiddenInput.addEventListener('compositionend', (e) => {
         isComposing = false;
-        if (e.data) {
-            commitCellInput(e.data.charAt(e.data.length - 1));
+        const committedText = e.data || hiddenInput.value || '';
+        const committedChar = committedText.charAt(committedText.length - 1);
+        if (committedChar) {
+            commitCellInput(committedChar);
+            moveToNextCell();
+            lastCommitAt = Date.now();
+            ignoreNextInput = true;
         }
         hiddenInput.value = '';
-        compositionEndedAt = Date.now();
+        skipPostCompositionKeyup = true;
     });
 
-    // 조합 종료 직후 keyup으로 Enter/Tab/Space 감지
-    // setTimeout(0)으로 defer — 일부 브라우저에서 keyup이 compositionend보다
-    // 먼저 발생하는 이벤트 순서 차이를 해결
+    // 조합 종료 직후 1회 keyup만 보정 처리
     hiddenInput.addEventListener('keyup', (e) => {
+        if (!skipPostCompositionKeyup) return;
+
         const key = e.key;
         const code = e.keyCode;
-        setTimeout(() => {
-            if (!compositionEndedAt || Date.now() - compositionEndedAt > 300) return;
-            compositionEndedAt = 0;
+        skipPostCompositionKeyup = false;
 
-            if (key === 'Enter' || code === 13) {
-                moveToNextCell();
-            } else if (key === 'Tab' || code === 9) {
-                moveToNextEntry(e.shiftKey);
-            } else if (key === ' ' || code === 32) {
-                state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
-                selectCell(state.selectedRow, state.selectedCol);
-            }
-        }, 0);
+        if (key === 'Enter' || code === 13 || key === 'Tab' || code === 9) {
+            return;
+        }
+
+        if (key === ' ' || code === 32) {
+            state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
+            selectCell(state.selectedRow, state.selectedCol);
+        }
     });
 
     // ── Input (조합 미리보기 + 영문 직접 입력) ──
@@ -163,6 +170,15 @@ function createHiddenInput() {
                     composingText.charAt(composingText.length - 1));
             }
             return;
+        }
+
+        if (ignoreNextInput && Date.now() - lastCommitAt < 120) {
+            ignoreNextInput = false;
+            hiddenInput.value = '';
+            return;
+        }
+        if (ignoreNextInput) {
+            ignoreNextInput = false;
         }
         if (e.inputType === 'insertCompositionText') return;
 

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.3"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.6"></script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation

- Prevent duplicate character input and unintended navigation caused by interactions between `compositionend`, `input`, and `keyup` events for Korean IME input.  
- Make post-composition key handling (Enter/Tab/Space) deterministic and ensure cell movement and direction toggling work reliably.

### Description

- Added state variables `ignoreNextInput`, `lastCommitAt`, and `skipPostCompositionKeyup` to coordinate composition and subsequent input events.  
- Updated `compositionend` handler to derive the committed character robustly, call `commitCellInput(...)` and `moveToNextCell()`, and set timing/ignore flags.  
- Modified `keyup` handling to only process a single post-composition key event, ignore Enter/Tab after composition, and handle space toggling of `state.direction`.  
- Added a short-timing guard in the `input` handler to drop the spurious input event that can follow composition (checks `lastCommitAt` within 120ms).  
- Bumped the client script version reference in the HTML from `v2.3` to `v2.6` to load the updated script.

### Testing

- Ran the JavaScript unit test suite via `npm test` and observed all tests passing.  
- Executed the automated browser integration/IME interaction tests via `npm run test:e2e` and observed success for the relevant keyboard/IME scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a85b3f2d8083309ec7a42b51407084)