### PR TITLE
Improve IME handling and key event logic for word puzzle input

### DIFF
--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -22,7 +22,10 @@ const state = {
 
 // IME composition tracking for Korean input
 let isComposing = false;
-let compositionEndedAt = 0; // compositionend 시점 기록 (keyup 연계용)
+let ignoreNextInput = false;
+let lastCommitAt = 0;
+let skipPostCompositionKeyup = false;
+let postCompositionKeyupDeadline = 0;
 
 // Single hidden input for all cell input (Hidden Input pattern)
 let hiddenInput = null;
@@ -100,9 +103,6 @@ async function initPuzzle() {
 // ══════════════════════════════════════════
 
 function createHiddenInput() {
-    let ignoreNextInput = false;
-    let lastCommitAt = 0;
-
     hiddenInput = document.createElement('input');
     hiddenInput.className = 'wp-hidden-input';
     hiddenInput.type = 'text';
@@ -124,6 +124,8 @@ function createHiddenInput() {
     hiddenInput.addEventListener('compositionstart', () => {
         isComposing = true;
         ignoreNextInput = false;
+        skipPostCompositionKeyup = false;
+        postCompositionKeyupDeadline = 0;
         hiddenInput.value = '';
     });
 
@@ -131,35 +133,40 @@ function createHiddenInput() {
         isComposing = false;
         const committedText = e.data || hiddenInput.value || '';
         const committedChar = committedText.charAt(committedText.length - 1);
-        if (committedChar) {
+
+        if (committedChar && committedChar.trim()) {
+            skipPostCompositionKeyup = true;
+            postCompositionKeyupDeadline = Date.now() + 300;
             commitCellInput(committedChar);
             moveToNextCell();
             lastCommitAt = Date.now();
             ignoreNextInput = true;
         }
+
         hiddenInput.value = '';
-        compositionEndedAt = Date.now();
     });
 
-    // 조합 종료 직후 keyup으로 Enter/Tab/Space 감지
-    // setTimeout(0)으로 defer — 일부 브라우저에서 keyup이 compositionend보다
-    // 먼저 발생하는 이벤트 순서 차이를 해결
+    // 조합 종료 직후 keyup은 1회만 처리
     hiddenInput.addEventListener('keyup', (e) => {
+        if (!skipPostCompositionKeyup) return;
+        if (Date.now() > postCompositionKeyupDeadline) {
+            skipPostCompositionKeyup = false;
+            postCompositionKeyupDeadline = 0;
+            return;
+        }
+
+        skipPostCompositionKeyup = false;
+        postCompositionKeyupDeadline = 0;
+
         const key = e.key;
         const code = e.keyCode;
-        setTimeout(() => {
-            if (!compositionEndedAt || Date.now() - compositionEndedAt > 300) return;
-            if (key === 'Enter' || code === 13 || key === 'Tab' || code === 9) {
-                compositionEndedAt = 0;
-                return;
-            }
 
-            compositionEndedAt = 0;
-            if (key === ' ' || code === 32) {
-                state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
-                selectCell(state.selectedRow, state.selectedCol);
-            }
-        }, 0);
+        if (key === 'Enter' || code === 13 || key === 'Tab' || code === 9) return;
+
+        if (key === ' ' || code === 32) {
+            state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
+            selectCell(state.selectedRow, state.selectedCol);
+        }
     });
 
     // ── Input (조합 미리보기 + 영문 직접 입력) ──
@@ -174,7 +181,7 @@ function createHiddenInput() {
             return;
         }
 
-        if (ignoreNextInput && Date.now() - lastCommitAt < 120) {
+        if (ignoreNextInput && Date.now() - lastCommitAt < 180) {
             ignoreNextInput = false;
             hiddenInput.value = '';
             return;
@@ -499,6 +506,13 @@ function onKeyDown(e) {
     if (state.selectedRow == null) return;
     if (isComposing) return;
 
+    if (skipPostCompositionKeyup
+        && Date.now() <= postCompositionKeyupDeadline
+        && (e.key === 'Enter' || e.key === 'Tab' || e.key === ' ')) {
+        e.preventDefault();
+        return;
+    }
+
     switch (e.key) {
         case 'ArrowLeft':
             e.preventDefault();
@@ -523,17 +537,20 @@ function onKeyDown(e) {
             break;
         case 'Tab':
             e.preventDefault();
-            compositionEndedAt = 0;
+            skipPostCompositionKeyup = false;
+            postCompositionKeyupDeadline = 0;
             moveToNextEntry(e.shiftKey);
             break;
         case 'Enter':
             e.preventDefault();
-            compositionEndedAt = 0;
+            skipPostCompositionKeyup = false;
+            postCompositionKeyupDeadline = 0;
             moveToNextCell();
             break;
         case ' ':
             e.preventDefault();
-            compositionEndedAt = 0;
+            skipPostCompositionKeyup = false;
+            postCompositionKeyupDeadline = 0;
             state.direction = state.direction === 'ACROSS' ? 'DOWN' : 'ACROSS';
             selectCell(state.selectedRow, state.selectedCol);
             break;

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.5"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=2.8"></script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation
- Fix unreliable behavior with Korean IME composition where `compositionend` was followed by duplicate `keyup`/key handling that caused missed or doubled input actions. 
- Prevent accidental Enter/Tab/Space from being processed immediately after committing composition text. 
- Reduce false-positive input ignore timing for rapid commits and keep the hidden input approach stable across browsers, and bump the script version.

### Description
- Introduce new IME-related flags `skipPostCompositionKeyup` and `postCompositionKeyupDeadline` and replace the old `compositionEndedAt` logic to ensure the post-composition `keyup` is handled only once. 
- On `compositionend` set a short deadline and mark to skip the next `keyup`, commit the final character, advance the cell, and set `ignoreNextInput`/`lastCommitAt` accordingly. 
- Update the `keyup`, `input`, and `keydown` handlers to honor the new skip/deadline behavior and to prevent processing `Enter`, `Tab`, or Space during the post-composition window, and increase the ignore timing threshold from `120`ms to `180`ms. 
- Remove redundant local variables in `createHiddenInput` and update the included script version in the HTML from `v=2.5` to `v=2.8`.

### Testing
- Ran the frontend unit test suite and linting for the web module, and they completed successfully. 
- Executed automated browser integration tests that cover IME composition scenarios and keyboard navigation, and they passed. 
- Performed smoke tests of puzzle play flows via the CI pipeline and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8634e91908330a586b8688bdcfec7)