### PR TITLE
Improve IME and Enter/Space key handling for puzzle inputs; bump script version

### DIFF
--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -262,6 +262,10 @@ function renderBoard() {
     }
 }
 
+function isMoveTriggerKey(e) {
+    return e.key === 'Enter' || e.key === ' ' || e.code === 'Enter' || e.code === 'Space';
+}
+
 function createCellInput(row, col, cellData) {
     const input = document.createElement('input');
     input.type = 'text';
@@ -296,9 +300,11 @@ function createCellInput(row, col, cellData) {
 
     // ── Keydown (이동 제어) ──
     input.addEventListener('keydown', (e) => {
-        if (isComposing) {
+        const composingNow = isComposing || e.isComposing || e.keyCode === 229;
+
+        if (composingNow) {
             // IME 조합 중에도 이동 키는 보류 등록
-            if (e.key === 'Enter' || e.key === ' ') {
+            if (isMoveTriggerKey(e)) {
                 e.preventDefault();
                 pendingMove = moveToNextCell;
             }
@@ -344,6 +350,19 @@ function createCellInput(row, col, cellData) {
                 }
                 break;
         }
+    });
+
+    // 일부 브라우저/IME 조합에서는 Enter 이동이 keydown 단계에서 누락될 수 있어 keyup에서 보정
+    input.addEventListener('keyup', (e) => {
+        if (isComposing || e.isComposing) return;
+        if (!isMoveTriggerKey(e)) return;
+
+        // keydown에서 이미 이동했다면 선택 셀이 바뀌므로 중복 이동 방지
+        const isStillSelected = state.selectedRow === row && state.selectedCol === col;
+        if (!isStillSelected) return;
+
+        e.preventDefault();
+        moveToNextCell();
     });
 
     return input;

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=3.1"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=3.3"></script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation
- Prevent IME compositions from triggering immediate navigation and reliably handle Enter/Space moves across browsers and IME implementations.
- Ensure that Enter/Space navigation is not lost on keydown in some browser/IME combos by adding a fallback on `keyup`.

### Description
- Added helper `isMoveTriggerKey` to centralize Enter/Space detection and used it in key handling logic.
- Improved IME detection by treating `isComposing`, `e.isComposing`, and `keyCode === 229` as composing states and queueing move actions while composing, then executing them on `compositionend`.
- Added a `keyup` handler to compensate for cases where `keydown` is missed for Enter/Space and to avoid duplicate moves when the selection already changed.
- Updated the HTML to bump the static script query version from `v=3.1` to `v=3.3` to ensure clients fetch the new script.

### Testing
- Ran the frontend linter with `npm run lint` and unit tests with `npm test`, and both completed successfully.
- Built the frontend assets with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a95952da20833091c6bb0358bea13c)