### PR TITLE
Improve IME (Hangul) composition handling and postpone cell selection during composition; bump script version

### DIFF
--- a/src/main/resources/static/js/game/bible-word-puzzle-play.js
+++ b/src/main/resources/static/js/game/bible-word-puzzle-play.js
@@ -297,7 +297,15 @@ function createCellInput(row, col, cellData) {
     });
 
     input.addEventListener('blur', () => {
-        if (composingCellKey === cellKey) composingCellKey = null;
+        if (composingCellKey === cellKey) {
+            // 한글 IME 조합 직후 blur가 먼저 오면 최종 글자가 아직 input.value에 반영되지 않을 수 있음
+            setTimeout(() => {
+                if (composingCellKey === cellKey) composingCellKey = null;
+                syncCellFromInput(row, col);
+            }, 0);
+            // 조합 중 셀 전환을 위한 pendingMove는 유지
+            return;
+        }
         pendingMove = null;
         syncCellFromInput(row, col);
     });
@@ -399,6 +407,18 @@ function onCellClick(row, col) {
 function selectCell(row, col) {
     const prevRow = state.selectedRow;
     const prevCol = state.selectedCol;
+
+    // 조합 중에는 즉시 포커스를 옮기지 않고 조합 완료 후 이동
+    if (prevRow != null && prevCol != null && (prevRow !== row || prevCol !== col)) {
+        const prevKey = `${prevRow},${prevCol}`;
+        if (composingCellKey === prevKey) {
+            pendingMove = () => selectCell(row, col);
+            const prevCellEl = getCellElement(prevRow, prevCol);
+            const prevInput = prevCellEl?.querySelector('.wp-cell-input');
+            if (prevInput) prevInput.blur();
+            return;
+        }
+    }
 
     state.selectedRow = row;
     state.selectedCol = col;

--- a/src/main/resources/templates/game/bible-word-puzzle-play.html
+++ b/src/main/resources/templates/game/bible-word-puzzle-play.html
@@ -103,7 +103,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-word-puzzle-play.js?v=3.5"></script>
+<script type="module" src="/js/game/bible-word-puzzle-play.js?v=3.7"></script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation
- Fix cases where Korean IME composition followed immediately by `blur` or cell switch would lose the final composed character or move focus before the composition result was synced. 
- Preserve pending navigation actions triggered during IME composition so movement completes after composition finishes. 
- Bump the client script version to ensure updated asset is loaded. 

### Description
- Update the input `blur` handler in `bible-word-puzzle-play.js` to defer `syncCellFromInput` with `setTimeout` when `composingCellKey === cellKey`, and return early so a composing cell does not lose its final character. 
- Add logic in `selectCell` to detect when the previously selected cell is mid-composition and enqueue the selection change in `pendingMove`, blur the previous input, and delay actual selection until composition completes. 
- Keep existing `compositionend` flow intact so it clears `composingCellKey`, runs `syncCellFromInput` on the next tick, and flushes any `pendingMove` actions. 
- Bump the HTML include for the module to `bible-word-puzzle-play.js?v=3.7` from `v=3.5`. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a97ad6a4208330ab3f403e48ce5ec1)