### PR TITLE
style: 랭킹 화면에서 완료/만점 컬럼 제거, 순위와 점수만 표시

### DIFF
--- a/src/main/resources/static/css/game/game-ranking.css
+++ b/src/main/resources/static/css/game/game-ranking.css
@@ -118,7 +118,7 @@
 
 .ranking-list-header {
     display: grid;
-    grid-template-columns: 3.5rem 1fr 4.5rem 3.5rem 3.5rem;
+    grid-template-columns: 3.5rem 1fr 5rem;
     align-items: center;
     padding: 0.6rem 0.75rem;
     background: var(--bs-light, #f8f9fa);
@@ -129,14 +129,12 @@
 }
 
 .rh-rank { text-align: center; }
-.rh-score,
-.rh-completed,
-.rh-perfect { text-align: center; }
+.rh-score { text-align: center; }
 
 /* 랭킹 아이템 */
 .ranking-item {
     display: grid;
-    grid-template-columns: 3.5rem 1fr 4.5rem 3.5rem 3.5rem;
+    grid-template-columns: 3.5rem 1fr 5rem;
     align-items: center;
     padding: 0.6rem 0.75rem;
     border-bottom: 1px solid var(--bs-border-color-translucent, rgba(0,0,0,0.075));
@@ -184,9 +182,7 @@
     white-space: nowrap;
 }
 
-.ri-score,
-.ri-completed,
-.ri-perfect {
+.ri-score {
     text-align: center;
     font-variant-numeric: tabular-nums;
 }
@@ -211,13 +207,13 @@
 /* 모바일 */
 @media (max-width: 576px) {
     .ranking-list-header {
-        grid-template-columns: 2.5rem 1fr 4rem 3rem 3rem;
+        grid-template-columns: 2.5rem 1fr 4.5rem;
         padding: 0.5rem;
         font-size: 0.7rem;
     }
 
     .ranking-item {
-        grid-template-columns: 2.5rem 1fr 4rem 3rem 3rem;
+        grid-template-columns: 2.5rem 1fr 4.5rem;
         padding: 0.5rem;
         font-size: 0.8rem;
     }

--- a/src/main/resources/static/js/game/game-ranking.js
+++ b/src/main/resources/static/js/game/game-ranking.js
@@ -78,8 +78,6 @@ function renderRankings(data) {
         document.getElementById('myRankNumber').textContent = myRanking.rank;
         document.getElementById('myRankTotal').textContent = `/ ${totalParticipants}명`;
         document.getElementById('myRankScore').textContent = formatScore(myRanking.rankingScore);
-        document.getElementById('myRankCompleted').textContent = myRanking.completedCount;
-        document.getElementById('myRankPerfect').textContent = myRanking.perfectCount;
         document.getElementById('myRankPercent').textContent =
             myRanking.topPercent != null ? `${myRanking.topPercent}%` : '-';
     }
@@ -116,8 +114,6 @@ function createRankingItem(item, isMe) {
             <span class="ri-name">${escapeHtml(item.nickname)}</span>
         </span>
         <span class="ri-score">${formatScore(item.rankingScore)}</span>
-        <span class="ri-completed">${item.completedCount}</span>
-        <span class="ri-perfect">${item.perfectCount}</span>
     `;
 
     return div;

--- a/src/main/resources/templates/game/game-ranking.html
+++ b/src/main/resources/templates/game/game-ranking.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 
 <head
-        th:replace="~{fragments/head :: head('게임 랭킹 - 순위 확인 | ElSeeker', true, '/css/game/game-ranking.css?v=1.1')}"
+        th:replace="~{fragments/head :: head('게임 랭킹 - 순위 확인 | ElSeeker', true, '/css/game/game-ranking.css?v=1.2')}"
         th:with="pageDescription='O/X 퀴즈, 객관식 퀴즈, 단어 퍼즐, 성경 타이핑 게임의 랭킹을 확인하세요.',
                  pageKeywords='성경 게임 랭킹,성경 퀴즈 순위,게임 점수,ElSeeker 랭킹'">
 </head>
@@ -37,14 +37,6 @@
                     <span class="my-stat-value" id="myRankScore">-</span>
                 </div>
                 <div class="my-stat">
-                    <span class="my-stat-label">완료</span>
-                    <span class="my-stat-value" id="myRankCompleted">-</span>
-                </div>
-                <div class="my-stat">
-                    <span class="my-stat-label">만점</span>
-                    <span class="my-stat-value" id="myRankPerfect">-</span>
-                </div>
-                <div class="my-stat">
                     <span class="my-stat-label">상위</span>
                     <span class="my-stat-value" id="myRankPercent">-%</span>
                 </div>
@@ -58,8 +50,6 @@
             <span class="rh-rank">순위</span>
             <span class="rh-nickname">닉네임</span>
             <span class="rh-score">점수</span>
-            <span class="rh-completed">완료</span>
-            <span class="rh-perfect">만점</span>
         </div>
         <div class="ranking-list" id="rankingList">
             <!-- JS에서 렌더링 -->
@@ -82,7 +72,7 @@
 
 <footer th:replace="~{fragments/footer :: footer}"></footer>
 
-<script type="module" src="/js/game/game-ranking.js?v=1.1"></script>
+<script type="module" src="/js/game/game-ranking.js?v=1.2"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 


### PR DESCRIPTION
- 랭킹 목록 헤더/아이템에서 완료(completedCount), 만점(perfectCount) 컬럼 제거
- 내 순위 카드에서도 완료/만점 stat 제거, 점수와 상위% 만 유지
- CSS 그리드를 3컬럼(순위, 닉네임, 점수)으로 단순화
- 닉네임 영역이 넓어져 모바일에서도 깔끔한 레이아웃

https://claude.ai/code/session_01W9zjiZePx4zN9aUrh32Uu6