### PR TITLE
style: 게임 메뉴 카드에서 태그(badge) 영역 제거

### DIFF
--- a/src/main/resources/static/css/game/game.css
+++ b/src/main/resources/static/css/game/game.css
@@ -61,23 +61,6 @@
     }
 }
 
-.game-card-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-    margin-top: auto;
-    padding-top: 1rem;
-    border-top: 1px solid #f1f5f9;
-}
-
-.game-card-meta .badge {
-    font-weight: 500;
-    color: #475569;
-    background-color: #f1f5f9 !important; /* Override text-bg-light for better contrast */
-    border: 1px solid #e2e8f0;
-    padding: 0.4em 0.6em;
-}
-
 /* Active Card Styles */
 .card-clickable {
     cursor: pointer;
@@ -122,10 +105,6 @@
 
 .card.coming-soon .text-muted {
     color: #cbd5e1 !important;
-}
-
-.card.coming-soon .badge {
-    opacity: 0.6;
 }
 
 @media (max-width: 576px) {

--- a/src/main/resources/templates/game/game.html
+++ b/src/main/resources/templates/game/game.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 게임 - 퀴즈, 타자, 단어 퍼즐 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.2,/css/game/game.css?v=2.2')}"
+<head th:replace="~{fragments/head :: head('성경 게임 - 퀴즈, 타자, 단어 퍼즐 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.2,/css/game/game.css?v=2.3')}"
       th:with="pageDescription='성경 O/X 퀴즈, 객관식 퀴즈, 성경 타자, 단어 퍼즐 등 재미있는 게임으로 말씀을 학습합니다.',
                pageKeywords='성경 퀴즈,성경 게임,성경 OX퀴즈,성경 타자,성경 단어 퍼즐,성경 학습 게임'"></head>
 <body class="has-fixed-nav">
@@ -23,14 +23,7 @@
                         </div>
                         <h2 class="h5 fw-bold text-dark mb-0">성경 O/X 퀴즈</h2>
                     </div>
-                    <div class="mb-3">
-                        <p class="text-muted small mb-0">참과 거짓을 빠르게 판단하는 O/X 퀴즈에 도전하세요.</p>
-                    </div>
-                    <div class="game-card-meta mt-auto">
-                        <span class="badge rounded-pill">성경책별</span>
-                        <span class="badge rounded-pill">O/X</span>
-                        <span class="badge rounded-pill">퀴즈</span>
-                    </div>
+                    <p class="text-muted small mb-0">참과 거짓을 빠르게 판단하는 O/X 퀴즈에 도전하세요.</p>
                 </div>
             </article>
         </div>
@@ -44,14 +37,7 @@
                         <div class="game-card-icon text-primary" aria-hidden="true">❓</div>
                         <h2 class="h5 fw-bold text-dark mb-0">성경 객관식 퀴즈</h2>
                     </div>
-                    <div class="mb-3">
-                        <p class="text-muted small mb-0">4지선다로 풀어보는 스테이지별 성경 퀴즈</p>
-                    </div>
-                    <div class="game-card-meta mt-auto">
-                        <span class="badge rounded-pill">스테이지</span>
-                        <span class="badge rounded-pill">4지선다</span>
-                        <span class="badge rounded-pill">퀴즈</span>
-                    </div>
+                    <p class="text-muted small mb-0">4지선다로 풀어보는 스테이지별 성경 퀴즈</p>
                 </div>
             </article>
         </div>
@@ -65,14 +51,7 @@
                         <div class="game-card-icon" aria-hidden="true">🧩</div>
                         <h2 class="h5 fw-bold text-dark mb-0">성경 단어 퍼즐</h2>
                     </div>
-                    <div class="mb-3">
-                        <p class="text-muted small mb-0">말씀의 핵심 단어를 연결하며 재미있게 복습합니다.</p>
-                    </div>
-                    <div class="game-card-meta mt-auto">
-                        <span class="badge rounded-pill">퍼즐</span>
-                        <span class="badge rounded-pill">가로·세로</span>
-                        <span class="badge rounded-pill">어휘</span>
-                    </div>
+                    <p class="text-muted small mb-0">말씀의 핵심 단어를 연결하며 재미있게 복습합니다.</p>
                 </div>
             </article>
         </div>
@@ -86,14 +65,7 @@
                         <div class="game-card-icon" aria-hidden="true">⌨️</div>
                         <h2 class="h5 fw-bold text-dark mb-0">성경 타자</h2>
                     </div>
-                    <div class="mb-3">
-                        <p class="text-muted small mb-0">말씀을 타이핑하며 암송과 집중력을 함께 높입니다.</p>
-                    </div>
-                    <div class="game-card-meta mt-auto">
-                        <span class="badge rounded-pill">성경책별</span>
-                        <span class="badge rounded-pill">타자</span>
-                        <span class="badge rounded-pill">필사</span>
-                    </div>
+                    <p class="text-muted small mb-0">말씀을 타이핑하며 암송과 집중력을 함께 높입니다.</p>
                 </div>
             </article>
         </div>
@@ -109,14 +81,7 @@
                         </div>
                         <h2 class="h5 fw-bold text-dark mb-0">제비뽑기</h2>
                     </div>
-                    <div class="mb-3">
-                        <p class="text-muted small mb-0">역할을 뽑을 때 성경적 방법으로 제비를 뽑아보세요.</p>
-                    </div>
-                    <div class="game-card-meta mt-auto">
-                        <span class="badge rounded-pill">랜덤</span>
-                        <span class="badge rounded-pill">추첨</span>
-                        <span class="badge rounded-pill">나눔</span>
-                    </div>
+                    <p class="text-muted small mb-0">역할을 뽑을 때 성경적 방법으로 제비를 뽑아보세요.</p>
                 </div>
             </article>
         </div>


### PR DESCRIPTION
모바일 환경에서 카드 크기를 줄여 UX를 개선한다.
태그 정보가 제목/설명과 대부분 중복되어 제거하고,
사용하지 않는 game-card-meta CSS도 함께 정리한다.

https://claude.ai/code/session_01HbeKPCHk7sXZ96m4GbKC9s