### PR TITLE
feat: 하단 네비게이션바 성경 탭 클릭 시 최근 읽던 위치로 이동

### DIFF
--- a/src/main/resources/static/js/common-nav.js
+++ b/src/main/resources/static/js/common-nav.js
@@ -3,12 +3,31 @@
  * - 클릭 시 Active 상태 즉시 전환 (SSR 깜빡임 대응)
  * - 스크롤 방향 기반 auto-hide (공존 페이지 전용)
  * - 키보드 네비게이션 (화살표키)
+ * - 성경 탭: 최근 읽던 위치가 있으면 해당 화면으로 바로 이동
  */
+
+import {LastReadStore} from "/js/storage-util.js?v=2.3";
 
 const nav = document.querySelector('.section-nav');
 
 if (nav) {
     const navItems = nav.querySelectorAll('.section-nav-item');
+
+    // --- 성경 탭: 최근 읽던 위치로 바로 이동 ---
+    const bibleNavItem = nav.querySelector('a[href="/web/bible/translation"]');
+    if (bibleNavItem) {
+        bibleNavItem.addEventListener('click', (e) => {
+            const lastRead = LastReadStore.get();
+            if (lastRead) {
+                e.preventDefault();
+                const verseUrl = new URL("/web/bible/verse", window.location.origin);
+                verseUrl.searchParams.set("translationId", lastRead.translationId);
+                verseUrl.searchParams.set("bookOrder", lastRead.bookOrder);
+                verseUrl.searchParams.set("chapterNumber", lastRead.chapterNumber);
+                window.location.href = `${verseUrl.pathname}${verseUrl.search}`;
+            }
+        });
+    }
 
     // --- 클릭 피드백: 즉시 Active 상태 전환 (SSR 페이지 리로드 깜빡임 대응) ---
     navItems.forEach(item => {

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -115,6 +115,6 @@
     </th:block>
 
     <script type="module" src="/js/bfcache-focus-reset.js?v=1.0"></script>
-    <script type="module" src="/js/common-nav.js?v=1.1"></script>
+    <script type="module" src="/js/common-nav.js?v=1.2"></script>
 </head>
 </html>


### PR DESCRIPTION
홈 화면의 성경 메뉴 카드와 동일하게, 하단 공통 네비게이션바의 성경 탭에서도
LastReadStore에 저장된 최근 읽기 위치가 있으면 해당 verse 화면으로 바로 이동하도록 개선.
