### PR TITLE
fix: 형광펜 색상 변경 시 기존 색상 클래스 제거되지 않는 버그 수정

### DIFF
--- a/src/main/resources/static/js/bible/verse-list.js
+++ b/src/main/resources/static/js/bible/verse-list.js
@@ -1108,6 +1108,7 @@ function setHighlightFromServer(verseNum, colorConfig) {
     if (!verseEl) {
         return;
     }
+    HIGHLIGHT_COLORS.forEach(color => verseEl.classList.remove(color.className));
     verseEl.classList.add(colorConfig.className);
     selection.highlightMap.set(String(verseNum), colorConfig);
 }

--- a/src/main/resources/templates/bible/verse-list.html
+++ b/src/main/resources/templates/bible/verse-list.html
@@ -90,7 +90,7 @@
     </div>
 </div>
 
-<script type="module" src="/js/bible/verse-list.js?v=2.6"></script>
+<script type="module" src="/js/bible/verse-list.js?v=2.7"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>


### PR DESCRIPTION
setHighlightFromServer()에서 새 색상 클래스를 추가하기 전에
기존 하이라이트 클래스를 모두 제거하도록 수정.
노란색→연두색 등 색상 변경 시 두 클래스가 동시에 남는 문제 해결.

https://claude.ai/code/session_01N7WfqqvW2vMRhiw5vLEMzR