### PR TITLE
fix: 하단 네비게이션 동일 섹션 중복 클릭 방지 강화

### DIFF
--- a/src/main/resources/static/js/common-nav.js
+++ b/src/main/resources/static/js/common-nav.js
@@ -15,11 +15,19 @@ if (nav) {
     const navItems = nav.querySelectorAll('.section-nav-item');
     let navClicked = false;
 
+    // --- 현재 페이지와 동일 섹션인지 URL 경로 비교 ---
+    function isSameSection(href) {
+        const currentPath = window.location.pathname;
+        if (href === '/') return currentPath === '/';
+        return currentPath === href || currentPath.startsWith(href + '/');
+    }
+
     // --- 성경 탭: 최근 읽던 위치로 바로 이동 ---
     const bibleNavItem = nav.querySelector('a[href="/web/bible/translation"]');
     if (bibleNavItem) {
         bibleNavItem.addEventListener('click', (e) => {
-            if (navClicked || bibleNavItem.classList.contains('active')) {
+            if (navClicked || bibleNavItem.classList.contains('active')
+                || isSameSection('/web/bible')) {
                 e.preventDefault();
                 return;
             }
@@ -39,7 +47,8 @@ if (nav) {
     // --- 중복 클릭 방지 + 클릭 피드백: 즉시 Active 상태 전환 (SSR 페이지 리로드 깜빡임 대응) ---
     navItems.forEach(item => {
         item.addEventListener('click', (e) => {
-            if (navClicked || item.classList.contains('active')) {
+            const href = item.getAttribute('href');
+            if (navClicked || item.classList.contains('active') || isSameSection(href)) {
                 e.preventDefault();
                 return;
             }

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -115,6 +115,6 @@
     </th:block>
 
     <script type="module" src="/js/bfcache-focus-reset.js?v=1.0"></script>
-    <script type="module" src="/js/common-nav.js?v=1.5"></script>
+    <script type="module" src="/js/common-nav.js?v=1.6"></script>
 </head>
 </html>


### PR DESCRIPTION
기존 active 클래스 기반 검사에 URL 경로 비교(isSameSection) 로직을
추가하여, Thymeleaf active 클래스가 정확히 세팅되지 않는 엣지 케이스에서도
동일 섹션 클릭 시 페이지 리로드와 불필요한 API 호출을 방지한다.