### PR TITLE
fix: 하단 네비게이션 메뉴 중복 클릭 시 불필요한 페이지 리로드 방지

### DIFF
--- a/src/main/resources/templates/fragments/section-nav.html
+++ b/src/main/resources/templates/fragments/section-nav.html
@@ -101,7 +101,7 @@
         document.addEventListener('DOMContentLoaded', function () {
             document.querySelectorAll('.section-nav-item').forEach(function (item) {
                 item.addEventListener('click', function (e) {
-                    if (this.classList.contains('active')) {
+                    if (this.pathname === window.location.pathname) {
                         e.preventDefault();
                     }
                 });

--- a/src/main/resources/templates/fragments/section-nav.html
+++ b/src/main/resources/templates/fragments/section-nav.html
@@ -97,6 +97,18 @@
         <span class="section-nav-label">커뮤니티</span>
     </a>
 
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.section-nav-item').forEach(function (item) {
+                item.addEventListener('click', function (e) {
+                    if (this.classList.contains('active')) {
+                        e.preventDefault();
+                    }
+                });
+            });
+        });
+    </script>
+
 </nav>
 </body>
 </html>


### PR DESCRIPTION
활성화된(active) 메뉴 항목 클릭 시 e.preventDefault()로 페이지 이동을 차단하여
불필요한 리로드 및 API 호출을 방지한다.
