### PR TITLE
refactor: replace inner scroll box with browser scroll for bible typing verses

### DIFF
--- a/src/main/resources/static/css/game/bible-typing.css
+++ b/src/main/resources/static/css/game/bible-typing.css
@@ -214,7 +214,6 @@
     padding-left: 0.5rem;
 }
 
-
 /* Verse Row */
 .typing-verse-row {
     border: 1px solid #f1f5f9;
@@ -313,8 +312,6 @@
     .typing-status-bar {
         padding: 1rem;
     }
-
-
 
     .status-item {
         min-width: auto;

--- a/src/main/resources/static/css/game/bible-typing.css
+++ b/src/main/resources/static/css/game/bible-typing.css
@@ -210,33 +210,10 @@
 .typing-verse-list {
     display: grid;
     gap: 1rem;
-    max-height: 600px;
-    overflow-y: auto;
     padding-right: 0.5rem;
     padding-left: 0.5rem;
-    /* Added padding-left to prevent clipping */
 }
 
-/* Scrollbar Styling */
-.typing-verse-list::-webkit-scrollbar {
-    width: 6px;
-}
-
-.typing-verse-list::-webkit-scrollbar-track {
-    background: #f1f5f9;
-    border-radius: 3px;
-}
-
-.typing-verse-list::-webkit-scrollbar-thumb {
-    background: #cbd5e1;
-    border-radius: 3px;
-}
-
-@media (hover: hover) and (pointer: fine) {
-    .typing-verse-list::-webkit-scrollbar-thumb:hover {
-        background: #94a3b8;
-    }
-}
 
 /* Verse Row */
 .typing-verse-row {

--- a/src/main/resources/templates/game/bible-typing.html
+++ b/src/main/resources/templates/game/bible-typing.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 
 <head
-        th:replace="~{fragments/head :: head('성경 타자 | ElSeeker', true, '/css/hero.css?v=2.3,/css/card.css?v=2.3,/css/game/bible-typing.css?v=2.7')}"
+        th:replace="~{fragments/head :: head('성경 타자 | ElSeeker', true, '/css/hero.css?v=2.3,/css/card.css?v=2.3,/css/game/bible-typing.css?v=2.8')}"
         th:with="robotsContent='noindex'">
 </head>
 


### PR DESCRIPTION
Remove max-height/overflow-y constraint and custom scrollbar styles from
.typing-verse-list so verses use native browser scroll. The sticky status
bar already keeps key metrics visible during scroll. This eliminates
nested scroll conflicts and improves mobile touch UX.

https://claude.ai/code/session_01TMgktLFcCkgFejWmQiGmCY