### PR TITLE
style: 타자 페이지 네비게이션바와 상태바 사이 불필요한 간격 제거

### DIFF
--- a/src/main/resources/static/css/game/bible-typing.css
+++ b/src/main/resources/static/css/game/bible-typing.css
@@ -11,10 +11,6 @@
     padding: 0;
 }
 
-.typing-page .content-wrapper {
-    padding-top: 0.5rem;
-}
-
 /* Typography */
 .typing-kicker {
     display: block;
@@ -141,8 +137,8 @@
 /* Sticky HUD Stack */
 .typing-sticky-stack {
     position: sticky;
-    top: 76px;
-    /* Below fixed header */
+    top: 56px;
+    /* Below fixed header (52px nav + 4px buffer) */
     z-index: 100;
     background: rgba(255, 255, 255, 0.95);
     backdrop-filter: blur(12px);

--- a/src/main/resources/static/css/game/bible-typing.css
+++ b/src/main/resources/static/css/game/bible-typing.css
@@ -6,6 +6,15 @@
     background: #f8fafc;
 }
 
+/* Collapse empty title bar spacing */
+.typing-page .top-nav-title {
+    padding: 0;
+}
+
+.typing-page .content-wrapper {
+    padding-top: 0.5rem;
+}
+
 /* Typography */
 .typing-kicker {
     display: block;

--- a/src/main/resources/templates/game/bible-typing.html
+++ b/src/main/resources/templates/game/bible-typing.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 
 <head
-        th:replace="~{fragments/head :: head('성경 타자 | ElSeeker', true, '/css/hero.css?v=2.3,/css/card.css?v=2.3,/css/game/bible-typing.css?v=2.8')}"
+        th:replace="~{fragments/head :: head('성경 타자 | ElSeeker', true, '/css/hero.css?v=2.3,/css/card.css?v=2.3,/css/game/bible-typing.css?v=2.9')}"
         th:with="robotsContent='noindex'">
 </head>
 


### PR DESCRIPTION
빈 타이틀 영역의 padding을 제거하고 content-wrapper 상단 여백을 줄여
네비게이션바와 진행 상태 영역 사이의 시각적 단절을 해소

https://claude.ai/code/session_01UqrSZFjacv19F4HRiuE81n