### PR TITLE
feat: add overview video and game action buttons to chapter-list book description

### DIFF
--- a/src/main/resources/static/css/bible/chapter-list.css
+++ b/src/main/resources/static/css/bible/chapter-list.css
@@ -1,14 +1,17 @@
+.book-info-section {
+    margin-bottom: 12px;
+}
+
 .book-description {
     display: block;
     background-color: #f8f9fa;
     border: 1px solid #dee2e6;
-    padding: 16px;
-    border-radius: 6px;
+    padding: 14px 16px;
+    border-radius: 6px 6px 0 0;
     font-weight: 500;
-    font-size: 1rem;
+    font-size: 0.95rem;
     color: #495057;
     transition: background-color 0.2s;
-    margin-bottom: 12px;
     line-height: 1.5;
     text-decoration: none;
 }
@@ -24,16 +27,66 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 8px; /* 텍스트와 화살표 간 여백 */
+    gap: 8px;
 }
 
 .book-description-text {
     flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .book-description-icon {
-    font-size: 1.25rem;
+    font-size: 1.1rem;
     flex-shrink: 0;
+}
+
+.book-action-buttons {
+    display: flex;
+    gap: 0;
+}
+
+.book-action-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 8px;
+    background-color: #f0f2f5;
+    border: 1px solid #dee2e6;
+    border-top: none;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: #495057;
+    text-decoration: none;
+    transition: background-color 0.2s;
+    cursor: pointer;
+}
+
+.book-action-btn:first-child {
+    border-radius: 0 0 0 6px;
+    border-right: none;
+}
+
+.book-action-btn:last-child {
+    border-radius: 0 0 6px 0;
+}
+
+.book-action-btn-icon {
+    font-size: 0.95rem;
+}
+
+.book-action-btn-label {
+    font-size: 0.85rem;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .book-action-btn:hover {
+        background-color: #e2e6ea;
+        text-decoration: none;
+    }
 }
 
 .chapter-grid {

--- a/src/main/resources/static/css/study/bible-overview-video.css
+++ b/src/main/resources/static/css/study/bible-overview-video.css
@@ -136,3 +136,16 @@
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     }
 }
+
+.bible-overview-video-card.is-highlighted {
+    animation: card-highlight 1.5s ease-out;
+}
+
+@keyframes card-highlight {
+    0%, 30% {
+        box-shadow: 0 0 0 3px #3b82f6;
+    }
+    100% {
+        box-shadow: none;
+    }
+}

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -15,7 +15,8 @@ const ROUTES = {
     BOOK_LIST: "/web/bible/book",
     CHAPTER_LIST: "/web/bible/chapter",
     CHAPTER_DESCRIPTION: "/web/bible/book/description",
-    VERSE_LIST: "/web/bible/verse"
+    VERSE_LIST: "/web/bible/verse",
+    OVERVIEW_VIDEO: "/web/study/bible-overview-video"
 };
 
 const DomHelper = {
@@ -29,6 +30,7 @@ const DomHelper = {
             pageTitleLabel: get("pageTitleLabel"),
             bookDescription: get("bookDescription"),
             bookDescriptionSummary: get("bookDescriptionSummary"),
+            overviewVideoBtn: get("overviewVideoBtn"),
             chapterList: get("chapterList"),
             prevBtn: get("prevBookBtn"),
             bookSelectLink: get("bookSelectLink"),
@@ -275,7 +277,8 @@ const App = {
             pageTitleLabel,
             bookSelectLinkLabel,
             bookSelectLink,
-            bookDescription
+            bookDescription,
+            overviewVideoBtn
         } = App.elements;
         if (translationTypeLabel && translationType) {
             translationTypeLabel.textContent = translationType;
@@ -291,6 +294,9 @@ const App = {
         }
         if (bookDescription) {
             bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
+        }
+        if (overviewVideoBtn) {
+            overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
         }
     },
 
@@ -353,7 +359,10 @@ const App = {
             pageTitleLabel.textContent = data.book.bookName;
         }
         if (bookDescriptionSummary) {
-            bookDescriptionSummary.textContent = data.book.descriptionSummary;
+            const summary = data.book.descriptionSummary || "";
+            bookDescriptionSummary.textContent = summary.length > 40
+                ? summary.substring(0, 40) + "…"
+                : summary;
         }
         if (chapterList) {
             chapterList.innerHTML = "";
@@ -404,6 +413,9 @@ const App = {
         if (App.elements.bookDescription) {
             App.elements.bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
         }
+        if (App.elements.overviewVideoBtn) {
+            App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
+        }
 
         App.updatePrevNextState();
 
@@ -437,6 +449,9 @@ window.addEventListener("popstate", async () => {
     }
     if (App.elements.bookDescription) {
         App.elements.bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
+    }
+    if (App.elements.overviewVideoBtn) {
+        App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
     }
     App.updatePrevNextState();
     if (!App.renderFromSessionStorage()) {

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -359,10 +359,7 @@ const App = {
             pageTitleLabel.textContent = data.book.bookName;
         }
         if (bookDescriptionSummary) {
-            const summary = data.book.descriptionSummary || "";
-            bookDescriptionSummary.textContent = summary.length > 40
-                ? summary.substring(0, 40) + "…"
-                : summary;
+            bookDescriptionSummary.textContent = data.book.descriptionSummary || "";
         }
         if (chapterList) {
             chapterList.innerHTML = "";
@@ -409,12 +406,6 @@ const App = {
 
         if (bookName) {
             App.updateHeader(TranslationStore.getCurrentTranslationType(), bookName);
-        }
-        if (App.elements.bookDescription) {
-            App.elements.bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
-        }
-        if (App.elements.overviewVideoBtn) {
-            App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
         }
 
         App.updatePrevNextState();

--- a/src/main/resources/static/js/study/bible-overview-video.js
+++ b/src/main/resources/static/js/study/bible-overview-video.js
@@ -88,6 +88,7 @@ class BibleOverviewVideo {
     init() {
         this.initNav();
         this.render();
+        this.scrollToTargetBook();
     }
 
     initNav() {
@@ -129,6 +130,7 @@ class BibleOverviewVideo {
 
             const link = document.createElement("a");
             link.className = "bible-overview-video-card";
+            link.dataset.bookOrder = book.bookOrder;
             link.href = book.youtubeUrl;
             link.target = "_blank";
             link.rel = "noopener noreferrer";
@@ -146,6 +148,7 @@ class BibleOverviewVideo {
 
         const div = document.createElement("div");
         div.className = "bible-overview-video-card is-disabled";
+        div.dataset.bookOrder = book.bookOrder;
         div.innerHTML = `
             <div class="bible-overview-video-thumb is-fallback">
                 <span class="bible-overview-video-play" aria-hidden="true"></span>
@@ -154,6 +157,20 @@ class BibleOverviewVideo {
             <span class="bible-overview-video-badge">준비중</span>
         `;
         return div;
+    }
+
+    scrollToTargetBook() {
+        const bookOrder = new URLSearchParams(window.location.search).get("bookOrder");
+        if (!bookOrder) return;
+
+        const targetCard = document.querySelector(`.bible-overview-video-card[data-book-order="${bookOrder}"]`);
+        if (!targetCard) return;
+
+        targetCard.scrollIntoView({behavior: "smooth", block: "center"});
+        targetCard.classList.add("is-highlighted");
+        targetCard.addEventListener("animationend", () => {
+            targetCard.classList.remove("is-highlighted");
+        }, {once: true});
     }
 }
 

--- a/src/main/resources/static/js/study/bible-overview-video.js
+++ b/src/main/resources/static/js/study/bible-overview-video.js
@@ -160,7 +160,7 @@ class BibleOverviewVideo {
     }
 
     scrollToTargetBook() {
-        const bookOrder = new URLSearchParams(window.location.search).get("bookOrder");
+        const bookOrder = parseInt(new URLSearchParams(window.location.search).get("bookOrder"), 10);
         if (!bookOrder) return;
 
         const targetCard = document.querySelector(`.bible-overview-video-card[data-book-order="${bookOrder}"]`);

--- a/src/main/resources/templates/bible/chapter-list.html
+++ b/src/main/resources/templates/bible/chapter-list.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 장 목록 - 책별 장 선택 | ElSeeker', true, '/css/bible/chapter-list.css?v=2.2')}"
+<head th:replace="~{fragments/head :: head('성경 장 목록 - 책별 장 선택 | ElSeeker', true, '/css/bible/chapter-list.css?v=2.3')}"
       th:with="pageDescription='선택한 성경 책의 장 목록과 책 개요를 빠르게 둘러볼 수 있습니다.',
                pageKeywords='성경 장,성경 읽기,성경 본문,성경책 개요'"></head>
 
@@ -10,18 +10,36 @@
         th:with="pageTitle='성경 장 목록', pageTitleVisible=true"></header>
 <main class="container content-wrapper mb-80">
     <!-- 책 개요 -->
-    <a id="bookDescription"
-       class="book-description text-decoration-none"
-       href="#"
-       aria-label="책 상세 보기"
-       title="책 개요를 보려면 클릭하세요">
-        <div class="book-description-row">
-            <div class="book-description-text">
-                📘 <span id="bookDescriptionSummary"></span>
+    <div class="book-info-section">
+        <a id="bookDescription"
+           class="book-description text-decoration-none"
+           href="#"
+           aria-label="책 상세 보기"
+           title="책 개요를 보려면 클릭하세요">
+            <div class="book-description-row">
+                <div class="book-description-text">
+                    📘 <span id="bookDescriptionSummary"></span>
+                </div>
+                <div class="book-description-icon">➡️</div>
             </div>
-            <div class="book-description-icon">➡️</div>
+        </a>
+        <div class="book-action-buttons">
+            <a id="overviewVideoBtn"
+               class="book-action-btn"
+               href="#"
+               aria-label="개요 영상 보기">
+                <span class="book-action-btn-icon" aria-hidden="true">▶️</span>
+                <span class="book-action-btn-label">개요 영상</span>
+            </a>
+            <a id="gameBtn"
+               class="book-action-btn"
+               href="/web/game/bible-ox-quiz/map"
+               aria-label="O/X 퀴즈 게임">
+                <span class="book-action-btn-icon" aria-hidden="true">🎮</span>
+                <span class="book-action-btn-label">게임</span>
+            </a>
         </div>
-    </a>
+    </div>
     <!-- 장 선택 그리드 -->
     <div id="chapterList" class="chapter-grid"></div>
 </main>
@@ -56,7 +74,7 @@
     </div>
 </div>
 
-<script type="module" src="/js/bible/chapter-list.js?v=2.2"></script>
+<script type="module" src="/js/bible/chapter-list.js?v=2.3"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/study/bible-overview-video.html
+++ b/src/main/resources/templates/study/bible-overview-video.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.0')}"
+<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.1')}"
       th:with="pageDescription='성경 66권 각 책의 개요를 영상으로 쉽게 배울 수 있는 학습 페이지입니다.',
                pageKeywords='성경 개요,성경 영상,성경 요약,성경 66권 요약,성경 공부 영상'"></head>
 <body class="has-fixed-nav has-dual-bottom-nav">
@@ -30,7 +30,7 @@
     </div>
 </main>
 
-<script type="module" src="/js/study/bible-overview-video.js?v=1.0"></script>
+<script type="module" src="/js/study/bible-overview-video.js?v=1.1"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>


### PR DESCRIPTION
책 설명 영역을 기존 단일 카드에서 요약 + 영상 + 게임 버튼 구조의 섹션으로 개선했고, 요약은 말줄임 처리하며 상세 페이지로 이동하도록 구성했습니다

개요 영상 페이지에서는 bookOrder 파라미터 기반으로 특정 책 위치로 스크롤 + 하이라이트 애니메이션 기능을 추가했습니다

JS 기반 문자열 자르기를 제거하고 CSS ellipsis로 대체하여 반응형 대응을 개선했고, 중복 href 설정 로직도 정리했습니다

bookOrder 파라미터 사용 시 정수 검증 로직을 추가하여 안정성을 확보했습니다