### PR TITLE
refactor: 게임 버튼 라벨을 퀴즈로 변경 및 코드 리펙토링

### DIFF
--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -448,9 +448,6 @@ window.addEventListener("popstate", async () => {
     if (App.elements.overviewVideoBtn) {
         App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
     }
-    if (App.elements.gameBtn) {
-        App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
-    }
     App.updatePrevNextState();
     if (!App.renderFromSessionStorage()) {
         await App.fetchChaptersFromAPI();

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -31,6 +31,7 @@ const DomHelper = {
             bookDescription: get("bookDescription"),
             bookDescriptionSummary: get("bookDescriptionSummary"),
             overviewVideoBtn: get("overviewVideoBtn"),
+            gameBtn: get("gameBtn"),
             chapterList: get("chapterList"),
             prevBtn: get("prevBookBtn"),
             bookSelectLink: get("bookSelectLink"),
@@ -298,6 +299,9 @@ const App = {
         if (overviewVideoBtn) {
             overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
         }
+        if (App.elements.gameBtn) {
+            App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
+        }
     },
 
     setupPrevNext: books => {
@@ -443,6 +447,9 @@ window.addEventListener("popstate", async () => {
     }
     if (App.elements.overviewVideoBtn) {
         App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
+    }
+    if (App.elements.gameBtn) {
+        App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
     }
     App.updatePrevNextState();
     if (!App.renderFromSessionStorage()) {

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -448,6 +448,9 @@ window.addEventListener("popstate", async () => {
     if (App.elements.overviewVideoBtn) {
         App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
     }
+    if (App.elements.gameBtn) {
+        App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
+    }
     App.updatePrevNextState();
     if (!App.renderFromSessionStorage()) {
         await App.fetchChaptersFromAPI();

--- a/src/main/resources/static/js/game/bible-ox-quiz-map.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz-map.js
@@ -61,8 +61,22 @@ class BibleOxQuizMap {
             this.renderStageList(data);
             this.hideLoading();
             this.stageListSection.classList.remove("d-none");
+            this.scrollToBookOrder();
         } catch (error) {
             this.showError(error.message);
+        }
+    }
+
+    scrollToBookOrder() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const bookOrder = parseInt(urlParams.get("bookOrder"), 10);
+        if (Number.isNaN(bookOrder)) {
+            return;
+        }
+        const cards = this.stageGrid.querySelectorAll(".ox-stage-card");
+        const targetCard = cards[bookOrder - 1];
+        if (targetCard) {
+            targetCard.scrollIntoView({ behavior: "smooth", block: "center" });
         }
     }
 

--- a/src/main/resources/templates/bible/chapter-list.html
+++ b/src/main/resources/templates/bible/chapter-list.html
@@ -36,7 +36,7 @@
                href="/web/game/bible-ox-quiz/map"
                aria-label="O/X 퀴즈 게임">
                 <span class="book-action-btn-icon" aria-hidden="true">🎮</span>
-                <span class="book-action-btn-label">게임</span>
+                <span class="book-action-btn-label">퀴즈</span>
             </a>
         </div>
     </div>

--- a/src/main/resources/templates/bible/chapter-list.html
+++ b/src/main/resources/templates/bible/chapter-list.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script type="module" src="/js/bible/chapter-list.js?v=2.3"></script>
+<script type="module" src="/js/bible/chapter-list.js?v=2.4"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/game/bible-ox-quiz-map.html
+++ b/src/main/resources/templates/game/bible-ox-quiz-map.html
@@ -39,7 +39,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.0"></script>
+<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.1"></script>
 </body>
 
 </html>


### PR DESCRIPTION
O/X 게임 버튼 라벨을 ‘퀴즈’로 변경해 실제 기능에 맞게 표현을 자연스럽게 수정했습니다

퀴즈 버튼 클릭 시 bookOrder 파라미터를 넘겨 해당 책 스테이지로 자동 스크롤되도록 연결했습니다

popstate 처리에서는 중복된 gameBtn href 설정 로직을 제거해 코드 책임을 정리했습니다

또한 bookName을 찾지 못하는 경우에도 gameBtn href가 항상 갱신되도록 보완해 뒤로가기/앞으로가기 상황의 링크 불일치를 수정했습니다