### PR TITLE
feat: OX 퀴즈 및 개요 영상 페이지 이동 시 from=chapter-list 파라미터를 전달해, 뒤로가기 시 chapter-list로 복귀하도록 네비게이션 흐름을 개선

### DIFF
--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -297,7 +297,7 @@ const App = {
             bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
         }
         if (overviewVideoBtn) {
-            overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
+            overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}&from=chapter-list`;
         }
         if (App.elements.gameBtn) {
             App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&from=chapter-list`;

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -449,7 +449,7 @@ window.addEventListener("popstate", async () => {
         App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
     }
     if (App.elements.gameBtn) {
-        App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
+        App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&from=chapter-list`;
     }
     App.updatePrevNextState();
     if (!App.renderFromSessionStorage()) {

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -446,7 +446,7 @@ window.addEventListener("popstate", async () => {
         App.elements.bookDescription.href = `${ROUTES.CHAPTER_DESCRIPTION}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
     }
     if (App.elements.overviewVideoBtn) {
-        App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
+        App.elements.overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}&from=chapter-list`;
     }
     if (App.elements.gameBtn) {
         App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&from=chapter-list`;

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -300,7 +300,8 @@ const App = {
             overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
         }
         if (App.elements.gameBtn) {
-            App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}`;
+            const chapterListUrl = `${ROUTES.CHAPTER_LIST}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
+            App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&returnUrl=${encodeURIComponent(chapterListUrl)}`;
         }
     },
 

--- a/src/main/resources/static/js/bible/chapter-list.js
+++ b/src/main/resources/static/js/bible/chapter-list.js
@@ -300,8 +300,7 @@ const App = {
             overviewVideoBtn.href = `${ROUTES.OVERVIEW_VIDEO}?bookOrder=${App.state.bookOrder}`;
         }
         if (App.elements.gameBtn) {
-            const chapterListUrl = `${ROUTES.CHAPTER_LIST}?translationId=${App.state.translationId}&bookOrder=${App.state.bookOrder}`;
-            App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&returnUrl=${encodeURIComponent(chapterListUrl)}`;
+            App.elements.gameBtn.href = `/web/game/bible-ox-quiz/map?bookOrder=${App.state.bookOrder}&from=chapter-list`;
         }
     },
 

--- a/src/main/resources/static/js/game/bible-ox-quiz-map.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz-map.js
@@ -119,12 +119,14 @@ class BibleOxQuizMap {
                 </div>
             `;
 
-            card.addEventListener("click", () => {
+            const navigateToQuiz = () => {
                 const quizUrl = this.from
                     ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&from=${this.from}`
                     : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
                 window.location.href = quizUrl;
-            });
+            };
+
+            card.addEventListener("click", navigateToQuiz);
 
             card.setAttribute("tabindex", "0");
             card.setAttribute("role", "button");
@@ -132,10 +134,7 @@ class BibleOxQuizMap {
             card.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    const quizUrl = this.from
-                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&from=${this.from}`
-                    : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
-                window.location.href = quizUrl;
+                    navigateToQuiz();
                 }
             });
 

--- a/src/main/resources/static/js/game/bible-ox-quiz-map.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz-map.js
@@ -47,10 +47,14 @@ class BibleOxQuizMap {
         this.backButton.classList.remove("d-none");
 
         const urlParams = new URLSearchParams(window.location.search);
-        this.returnUrl = urlParams.get("returnUrl");
+        this.from = urlParams.get("from");
 
         this.backButton.addEventListener("click", () => {
-            window.location.href = this.returnUrl || "/web/game";
+            if (this.from === "chapter-list") {
+                history.back();
+                return;
+            }
+            window.location.href = "/web/game";
         });
     }
 
@@ -116,8 +120,8 @@ class BibleOxQuizMap {
             `;
 
             card.addEventListener("click", () => {
-                const quizUrl = this.returnUrl
-                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&returnUrl=${encodeURIComponent(this.returnUrl)}`
+                const quizUrl = this.from
+                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&from=${this.from}`
                     : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
                 window.location.href = quizUrl;
             });
@@ -128,8 +132,8 @@ class BibleOxQuizMap {
             card.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    const quizUrl = this.returnUrl
-                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&returnUrl=${encodeURIComponent(this.returnUrl)}`
+                    const quizUrl = this.from
+                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&from=${this.from}`
                     : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
                 window.location.href = quizUrl;
                 }

--- a/src/main/resources/static/js/game/bible-ox-quiz-map.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz-map.js
@@ -45,8 +45,12 @@ class BibleOxQuizMap {
             pageTitleLabel.classList.remove("d-none");
         }
         this.backButton.classList.remove("d-none");
+
+        const urlParams = new URLSearchParams(window.location.search);
+        this.returnUrl = urlParams.get("returnUrl");
+
         this.backButton.addEventListener("click", () => {
-            window.location.href = "/web/game";
+            window.location.href = this.returnUrl || "/web/game";
         });
     }
 
@@ -112,7 +116,10 @@ class BibleOxQuizMap {
             `;
 
             card.addEventListener("click", () => {
-                window.location.href = `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
+                const quizUrl = this.returnUrl
+                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&returnUrl=${encodeURIComponent(this.returnUrl)}`
+                    : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
+                window.location.href = quizUrl;
             });
 
             card.setAttribute("tabindex", "0");
@@ -121,7 +128,10 @@ class BibleOxQuizMap {
             card.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    window.location.href = `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
+                    const quizUrl = this.returnUrl
+                    ? `/web/game/bible-ox-quiz?stage=${stage.stageNumber}&returnUrl=${encodeURIComponent(this.returnUrl)}`
+                    : `/web/game/bible-ox-quiz?stage=${stage.stageNumber}`;
+                window.location.href = quizUrl;
                 }
             });
 

--- a/src/main/resources/static/js/game/bible-ox-quiz.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz.js
@@ -6,6 +6,7 @@
  */
 
 import { checkAuthStatus, buildLoginRedirectUrl } from "/js/auth/auth-check.js";
+import { TranslationStore } from "/js/storage-util.js";
 
 const API_BASE = "/api/v1/game/bible-ox-quiz";
 const MAX_STAGE = 66;
@@ -82,10 +83,18 @@ class BibleOxQuiz {
         this.backButton.classList.remove("d-none");
 
         const urlParams = new URLSearchParams(window.location.search);
-        const returnUrl = urlParams.get("returnUrl");
+        this.from = urlParams.get("from");
 
         this.backButton.addEventListener("click", () => {
-            window.location.href = returnUrl || "/web/game/bible-ox-quiz/map";
+            if (this.from === "chapter-list") {
+                const translationId = TranslationStore.getCurrentTranslationId();
+                const bookOrder = parseInt(urlParams.get("stage"), 10);
+                window.location.href = translationId && bookOrder
+                    ? `/web/bible/chapter?translationId=${translationId}&bookOrder=${bookOrder}`
+                    : "/web/game/bible-ox-quiz/map";
+                return;
+            }
+            window.location.href = "/web/game/bible-ox-quiz/map";
         });
     }
 

--- a/src/main/resources/static/js/game/bible-ox-quiz.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz.js
@@ -80,8 +80,12 @@ class BibleOxQuiz {
             pageTitleLabel.classList.remove("d-none");
         }
         this.backButton.classList.remove("d-none");
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const returnUrl = urlParams.get("returnUrl");
+
         this.backButton.addEventListener("click", () => {
-            window.location.href = "/web/game/bible-ox-quiz/map";
+            window.location.href = returnUrl || "/web/game/bible-ox-quiz/map";
         });
     }
 

--- a/src/main/resources/static/js/study/bible-overview-video.js
+++ b/src/main/resources/static/js/study/bible-overview-video.js
@@ -100,7 +100,15 @@ class BibleOverviewVideo {
             pageTitleLabel.classList.remove("d-none");
         }
         this.backButton.classList.remove("d-none");
+
+        const urlParams = new URLSearchParams(window.location.search);
+        this.from = urlParams.get("from");
+
         this.backButton.addEventListener("click", () => {
+            if (this.from === "chapter-list") {
+                history.back();
+                return;
+            }
             window.location.href = "/web/study";
         });
     }

--- a/src/main/resources/templates/bible/chapter-list.html
+++ b/src/main/resources/templates/bible/chapter-list.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script type="module" src="/js/bible/chapter-list.js?v=2.4"></script>
+<script type="module" src="/js/bible/chapter-list.js?v=2.5"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/bible/chapter-list.html
+++ b/src/main/resources/templates/bible/chapter-list.html
@@ -74,7 +74,7 @@
     </div>
 </div>
 
-<script type="module" src="/js/bible/chapter-list.js?v=2.5"></script>
+<script type="module" src="/js/bible/chapter-list.js?v=2.6"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/game/bible-ox-quiz-map.html
+++ b/src/main/resources/templates/game/bible-ox-quiz-map.html
@@ -39,7 +39,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.1"></script>
+<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.2"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/game/bible-ox-quiz.html
+++ b/src/main/resources/templates/game/bible-ox-quiz.html
@@ -102,7 +102,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-ox-quiz.js?v=2.0"></script>
+<script type="module" src="/js/game/bible-ox-quiz.js?v=2.1"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/study/bible-overview-video.html
+++ b/src/main/resources/templates/study/bible-overview-video.html
@@ -30,7 +30,7 @@
     </div>
 </main>
 
-<script type="module" src="/js/study/bible-overview-video.js?v=1.1"></script>
+<script type="module" src="/js/study/bible-overview-video.js?v=1.2"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>


### PR DESCRIPTION
OX 퀴즈 및 개요 영상 페이지 이동 시 from=chapter-list 파라미터를 전달해, 뒤로가기 시 chapter-list로 복귀하도록 네비게이션 흐름을 개선했습니다

기존 returnUrl 방식 대신 from 파라미터 기반 패턴으로 통일해 verse-list와 일관된 구조를 적용했습니다

quiz/overview 페이지의 뒤로가기 버튼은 TranslationStore와 stage 정보를 기반으로 chapter-list URL을 재구성하도록 처리했습니다

popstate 처리에서 누락된 from 파라미터를 보완하고, 중복 네비게이션 로직을 제거해 안정성과 코드 일관성을 개선했습니다