### PR TITLE
feat: 성경 개요 영상 및 OX 퀴즈 맵 페이지에 스포트라이트 효과 적용

### DIFF
--- a/src/main/resources/static/css/game/bible-ox-quiz-map.css
+++ b/src/main/resources/static/css/game/bible-ox-quiz-map.css
@@ -85,7 +85,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .ox-stage-card:hover {
+    .ox-stage-card:hover:not(.is-spotlight-target) {
         transform: translateY(-2px);
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
     }
@@ -104,7 +104,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .ox-stage-card.is-completed:hover {
+    .ox-stage-card.is-completed:hover:not(.is-spotlight-target) {
         border-color: #86efac;
     }
 }
@@ -119,7 +119,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .ox-stage-card.has-progress:hover {
+    .ox-stage-card.has-progress:hover:not(.is-spotlight-target) {
         border-color: #93c5fd;
     }
 }
@@ -206,4 +206,35 @@
     .ox-stage-grid {
         grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
     }
+}
+
+/* Spotlight overlay */
+.ox-quiz-spotlight-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 1040;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+}
+
+.ox-quiz-spotlight-overlay.is-active {
+    opacity: 1;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+/* Spotlight target card */
+.ox-stage-card.is-spotlight-target {
+    position: relative;
+    z-index: 1041;
+    background: #fff;
+    border-radius: 14px;
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 1),
+                0 4px 24px rgba(0, 0, 0, 0.25);
+    transition: box-shadow 0.4s ease, background 0.4s ease;
 }

--- a/src/main/resources/static/css/study/bible-overview-video.css
+++ b/src/main/resources/static/css/study/bible-overview-video.css
@@ -137,15 +137,33 @@
     }
 }
 
-.bible-overview-video-card.is-highlighted {
-    animation: card-highlight 1.5s ease-out;
+/* Spotlight overlay */
+.video-spotlight-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 1040;
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
 }
 
-@keyframes card-highlight {
-    0%, 30% {
-        box-shadow: 0 0 0 3px #3b82f6;
-    }
-    100% {
-        box-shadow: none;
-    }
+.video-spotlight-overlay.is-active {
+    opacity: 1;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+/* Spotlight target card */
+.bible-overview-video-card.is-spotlight-target {
+    position: relative;
+    z-index: 1041;
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 1),
+                0 4px 24px rgba(0, 0, 0, 0.25);
+    transition: box-shadow 0.4s ease, background 0.4s ease;
 }

--- a/src/main/resources/static/css/study/bible-overview-video.css
+++ b/src/main/resources/static/css/study/bible-overview-video.css
@@ -161,6 +161,7 @@
 .bible-overview-video-card.is-spotlight-target {
     position: relative;
     z-index: 1041;
+    overflow: visible;
     background: #fff;
     border-radius: 0.75rem;
     box-shadow: 0 0 0 4px rgba(255, 255, 255, 1),

--- a/src/main/resources/static/css/study/bible-overview-video.css
+++ b/src/main/resources/static/css/study/bible-overview-video.css
@@ -36,7 +36,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .bible-overview-video-card:hover:not(.is-disabled) {
+    .bible-overview-video-card:hover:not(.is-disabled):not(.is-spotlight-target) {
         transform: translateY(-3px);
         box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
         border-color: #cbd5e1;
@@ -90,7 +90,7 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .bible-overview-video-card:hover:not(.is-disabled) .bible-overview-video-play {
+    .bible-overview-video-card:hover:not(.is-disabled):not(.is-spotlight-target) .bible-overview-video-play {
         background: rgba(220, 38, 38, 0.85);
     }
 }

--- a/src/main/resources/static/js/game/bible-ox-quiz-map.js
+++ b/src/main/resources/static/js/game/bible-ox-quiz-map.js
@@ -83,9 +83,34 @@ class BibleOxQuizMap {
         }
         const cards = this.stageGrid.querySelectorAll(".ox-stage-card");
         const targetCard = cards[bookOrder - 1];
-        if (targetCard) {
-            targetCard.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (!targetCard) {
+            return;
         }
+
+        setTimeout(() => {
+            const overlay = document.createElement("div");
+            overlay.className = "ox-quiz-spotlight-overlay";
+            document.body.appendChild(overlay);
+
+            targetCard.classList.add("is-spotlight-target");
+
+            requestAnimationFrame(() => {
+                overlay.classList.add("is-active");
+                targetCard.scrollIntoView({behavior: "smooth", block: "center"});
+            });
+
+            let dismissed = false;
+            const dismiss = () => {
+                if (dismissed) return;
+                dismissed = true;
+                overlay.classList.remove("is-active");
+                targetCard.classList.remove("is-spotlight-target");
+                overlay.addEventListener("transitionend", () => overlay.remove(), {once: true});
+            };
+
+            overlay.addEventListener("click", dismiss, {once: true});
+            setTimeout(dismiss, 4000);
+        }, 100);
     }
 
     renderStageList(data) {

--- a/src/main/resources/static/js/study/bible-overview-video.js
+++ b/src/main/resources/static/js/study/bible-overview-video.js
@@ -174,11 +174,30 @@ class BibleOverviewVideo {
         const targetCard = document.querySelector(`.bible-overview-video-card[data-book-order="${bookOrder}"]`);
         if (!targetCard) return;
 
-        targetCard.scrollIntoView({behavior: "smooth", block: "center"});
-        targetCard.classList.add("is-highlighted");
-        targetCard.addEventListener("animationend", () => {
-            targetCard.classList.remove("is-highlighted");
-        }, {once: true});
+        setTimeout(() => {
+            const overlay = document.createElement("div");
+            overlay.className = "video-spotlight-overlay";
+            document.body.appendChild(overlay);
+
+            targetCard.classList.add("is-spotlight-target");
+
+            requestAnimationFrame(() => {
+                overlay.classList.add("is-active");
+                targetCard.scrollIntoView({behavior: "smooth", block: "center"});
+            });
+
+            let dismissed = false;
+            const dismiss = () => {
+                if (dismissed) return;
+                dismissed = true;
+                overlay.classList.remove("is-active");
+                targetCard.classList.remove("is-spotlight-target");
+                overlay.addEventListener("transitionend", () => overlay.remove(), {once: true});
+            };
+
+            overlay.addEventListener("click", dismiss, {once: true});
+            setTimeout(dismiss, 4000);
+        }, 100);
     }
 }
 

--- a/src/main/resources/templates/game/bible-ox-quiz-map.html
+++ b/src/main/resources/templates/game/bible-ox-quiz-map.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 
 <head
-        th:replace="~{fragments/head :: head('성경 O/X 퀴즈 | ElSeeker', true, '/css/card.css?v=2.3,/css/game/bible-ox-quiz-map.css?v=3.0')}"
+        th:replace="~{fragments/head :: head('성경 O/X 퀴즈 | ElSeeker', true, '/css/card.css?v=2.3,/css/game/bible-ox-quiz-map.css?v=3.1')}"
         th:with="robotsContent='noindex'">
 </head>
 
@@ -39,7 +39,7 @@
     </section>
 </main>
 
-<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.2"></script>
+<script type="module" src="/js/game/bible-ox-quiz-map.js?v=2.3"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/study/bible-overview-video.html
+++ b/src/main/resources/templates/study/bible-overview-video.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.2')}"
+<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.3')}"
       th:with="pageDescription='성경 66권 각 책의 개요를 영상으로 쉽게 배울 수 있는 학습 페이지입니다.',
                pageKeywords='성경 개요,성경 영상,성경 요약,성경 66권 요약,성경 공부 영상'"></head>
 <body class="has-fixed-nav has-dual-bottom-nav">

--- a/src/main/resources/templates/study/bible-overview-video.html
+++ b/src/main/resources/templates/study/bible-overview-video.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.3')}"
+<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.4')}"
       th:with="pageDescription='성경 66권 각 책의 개요를 영상으로 쉽게 배울 수 있는 학습 페이지입니다.',
                pageKeywords='성경 개요,성경 영상,성경 요약,성경 66권 요약,성경 공부 영상'"></head>
 <body class="has-fixed-nav has-dual-bottom-nav">

--- a/src/main/resources/templates/study/bible-overview-video.html
+++ b/src/main/resources/templates/study/bible-overview-video.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.1')}"
+<head th:replace="~{fragments/head :: head('성경 66권 개요 영상 - 책별 요약 | ElSeeker', true, '/css/hero.css?v=2.2,/css/card.css?v=2.3,/css/study/bible-overview-video.css?v=1.2')}"
       th:with="pageDescription='성경 66권 각 책의 개요를 영상으로 쉽게 배울 수 있는 학습 페이지입니다.',
                pageKeywords='성경 개요,성경 영상,성경 요약,성경 66권 요약,성경 공부 영상'"></head>
 <body class="has-fixed-nav has-dual-bottom-nav">
@@ -30,7 +30,7 @@
     </div>
 </main>
 
-<script type="module" src="/js/study/bible-overview-video.js?v=1.2"></script>
+<script type="module" src="/js/study/bible-overview-video.js?v=1.3"></script>
 <div th:replace="~{fragments/section-nav :: section-nav}"></div>
 </body>
 </html>


### PR DESCRIPTION
성경 개요 영상 및 OX 퀴즈 맵 페이지에서 **특정 책 카드에 스포트라이트 효과(오버레이 + 강조)**를 적용해 사용자 포커스를 개선했습니다

카드에 적용된 overflow: hidden으로 인해 box-shadow가 잘리는 문제를 overflow: visible로 수정했습니다

hover 스타일이 스포트라이트를 덮어쓰던 문제를 :not(.is-spotlight-target) 조건으로 분리해 강조 효과가 유지되도록 개선했습니다